### PR TITLE
Fix dataclass construction and add Orion turn-one test

### DIFF
--- a/eclipse_ai/types.py
+++ b/eclipse_ai/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
-from dataclasses import dataclass, field, asdict, is_dataclass
-from typing import Dict, List, Optional, Tuple, Any
+import sys
+from dataclasses import dataclass, field, asdict, is_dataclass, fields
+from typing import Dict, List, Optional, Tuple, Any, get_args, get_origin, get_type_hints
 from enum import Enum
 import json
 
@@ -8,12 +9,13 @@ def _build_dataclass(cls, data: Dict[str, Any]):
     """Recursively coerce nested dicts/lists into a dataclass instance."""
     if not is_dataclass(cls):
         return data
+    type_hints = get_type_hints(cls, globalns=sys.modules[cls.__module__].__dict__)
     kwargs = {}
     for f in fields(cls):
         if f.name not in data:
             continue  # keep default
         v = data[f.name]
-        ft = f.type
+        ft = type_hints.get(f.name, f.type)
         origin = get_origin(ft)
 
         if is_dataclass(ft) and isinstance(v, dict):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+testpaths = tests

--- a/tests/test_rules_engine.py
+++ b/tests/test_rules_engine.py
@@ -1,0 +1,119 @@
+from eclipse_ai.rules_engine import legal_actions
+from eclipse_ai.types import ActionType, GameState
+
+
+def _orion_turn_one_state() -> GameState:
+    """Construct a minimal, rules-respecting two-player opening state."""
+
+    state_dict = {
+        "round": 1,
+        "active_player": "orion",
+        "players": {
+            "orion": {
+                "player_id": "orion",
+                "color": "purple",
+                # Orion starts with strong materials economy and modest science.
+                "resources": {"money": 3, "science": 4, "materials": 3},
+                # Basic interceptor design matching the reference ship sheet.
+                "ship_designs": {
+                    "interceptor": {
+                        "computer": 1,
+                        "shield": 0,
+                        "initiative": 2,
+                        "hull": 1,
+                        "cannons": 1,
+                        "missiles": 0,
+                        "drive": 1,
+                    }
+                },
+                "known_techs": [],
+            },
+            "hydran": {
+                "player_id": "hydran",
+                "color": "green",
+                "resources": {"money": 3, "science": 3, "materials": 2},
+                "known_techs": [],
+            },
+        },
+        "map": {
+            "hexes": {
+                # Orion home system with occupied planets and starting fleet.
+                "000": {
+                    "id": "000",
+                    "ring": 0,
+                    "planets": [
+                        {"type": "yellow", "colonized_by": "orion"},
+                        {"type": "blue", "colonized_by": None},
+                    ],
+                    "pieces": {
+                        "orion": {
+                            "ships": {"interceptor": 2},
+                            "starbase": 0,
+                            "discs": 1,
+                            "cubes": {"yellow": 2, "blue": 1},
+                            "discovery": 0,
+                        }
+                    },
+                    "ancients": 0,
+                    "monolith": False,
+                },
+                # Adjacent unexplored sector with open planets to encourage influence/explore.
+                "101": {
+                    "id": "101",
+                    "ring": 1,
+                    "planets": [
+                        {"type": "brown", "colonized_by": None},
+                        {"type": "yellow", "colonized_by": None},
+                    ],
+                    "pieces": {},
+                    "ancients": 0,
+                    "monolith": False,
+                },
+                # Rival home system to show enemy presence.
+                "200": {
+                    "id": "200",
+                    "ring": 1,
+                    "planets": [
+                        {"type": "yellow", "colonized_by": "hydran"},
+                        {"type": "brown", "colonized_by": None},
+                    ],
+                    "pieces": {
+                        "hydran": {
+                            "ships": {"interceptor": 2},
+                            "starbase": 0,
+                            "discs": 1,
+                            "cubes": {"yellow": 2, "brown": 1},
+                            "discovery": 0,
+                        }
+                    },
+                    "ancients": 0,
+                    "monolith": False,
+                },
+            }
+        },
+        # Tier I techs are available and affordable with current science.
+        "tech_display": {
+            "available": ["Plasma Cannon I", "Fusion Drive I", "Advanced Mining"],
+            "tier_counts": {"I": 6, "II": 0, "III": 0},
+        },
+        # First ring bag seeded so explore actions are legal.
+        "bags": {"R1": {"unknown": 6}},
+    }
+    return GameState.from_dict(state_dict)
+
+
+def test_orion_turn_one_action_suite():
+    state = _orion_turn_one_state()
+    actions = legal_actions(state, "orion")
+    action_types = {a.type for a in actions}
+
+    # Ensure the core first-turn options are present.
+    assert ActionType.PASS in action_types
+    assert ActionType.EXPLORE in action_types
+    assert ActionType.BUILD in action_types
+    assert ActionType.RESEARCH in action_types
+    assert ActionType.INFLUENCE in action_types
+
+    # Confirm the dataclass conversion preserved nested structures.
+    assert state.players["orion"].resources.materials == 3
+    assert state.map.hexes["000"].pieces["orion"].ships["interceptor"] == 2


### PR DESCRIPTION
## Summary
- resolve postponed annotations when constructing nested dataclasses so GameState.from_dict yields typed objects
- add pytest configuration to focus on repository tests and ensure package importability
- add a turn-one Orion vs Hydran scenario regression test covering the legal action enumerator

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5d24a278c832db99f9ae9d8c44930