### PR TITLE
Adjust render report default output location

### DIFF
--- a/eclipse_ai/eclipse_test/render_report.py
+++ b/eclipse_ai/eclipse_test/render_report.py
@@ -146,7 +146,7 @@ def main() -> None:
     parser.add_argument(
         "--output",
         type=Path,
-        default=Path("test_report.svg"),
+        default=Path("tests") / "test_report.svg",
         help="Destination path for the rendered SVG report.",
     )
     parser.add_argument("--title", help="Optional custom title for the report header.")


### PR DESCRIPTION
## Summary
- update the render report CLI default output path to point to the tests directory
- rely on the existing directory creation logic to keep the SVG report stored under tests by default

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5f709e70c832db37f8ea6b8341d9c