### PR TITLE
Fix Orion opening heuristics

### DIFF
--- a/eclipse_ai/rules_engine.py
+++ b/eclipse_ai/rules_engine.py
@@ -126,7 +126,7 @@ def _enum_build(state: GameState, you: PlayerState) -> List[Action]:
             out.append(Action(ActionType.BUILD, {"hex": hx.id, "ships": {"cruiser": 1}}))
         if mats >= 2 * SHIP_COSTS["interceptor"]:
             out.append(Action(ActionType.BUILD, {"hex": hx.id, "ships": {"interceptor": 2}}))
-        elif mats >= SHIP_COSTS["interceptor"]:
+        if mats >= SHIP_COSTS["interceptor"]:
             out.append(Action(ActionType.BUILD, {"hex": hx.id, "ships": {"interceptor": 1}}))
 
     return out

--- a/tests/test_rules_engine.py
+++ b/tests/test_rules_engine.py
@@ -126,7 +126,7 @@ _ORION_OPENING: Dict[str, Any] = {
             "player_id": "P1",
             "color": "purple",
             "known_techs": ["Gauss Shield", "Neutron Bombs"],  # Orion Hegemony starting tech (Rise of the Ancients)
-            "resources": {"money": 3, "science": 3, "materials": 5},
+            "resources": {"money": 3, "science": 1, "materials": 5},
             "ship_designs": {
                 "interceptor": {
                     "computer": 1,


### PR DESCRIPTION
## Summary
- correct the Orion Hegemony opening fixture to reflect its limited starting science
- ensure build recommendations always include a single-interceptor option even when two are affordable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5faf85edc832d8602c9aebaf48b88