### PR TITLE
Enforce ship design and build legality rules

### DIFF
--- a/eclipse_ai/game_models.py
+++ b/eclipse_ai/game_models.py
@@ -84,15 +84,7 @@ class Resources:
     science: int = 0
     materials: int = 0
 
-@dataclass
-class ShipDesign:
-    computer: int = 0
-    shield: int = 0
-    initiative: int = 0
-    hull: int = 1
-    cannons: int = 0
-    missiles: int = 0
-    drive: int = 0
+from .types import ShipDesign
 
 @dataclass
 class Pieces:
@@ -116,6 +108,7 @@ class Hex:
     pieces: Dict[str, Pieces] = field(default_factory=dict)  # player_id -> Pieces
     ancients: int = 0
     monolith: bool = False
+    orbital: bool = False
     anomaly: bool = False
 
 @dataclass
@@ -132,6 +125,7 @@ class PlayerState:
     ship_designs: Dict[str, ShipDesign] = field(default_factory=dict)  # interceptor, cruiser, dreadnought, starbase
     reputation: List[int] = field(default_factory=list)
     diplomacy: Dict[str, str] = field(default_factory=dict)
+    available_components: Dict[str, int] = field(default_factory=dict)
 
 @dataclass
 class MapState:

--- a/eclipse_ai/ship_parts.py
+++ b/eclipse_ai/ship_parts.py
@@ -1,0 +1,137 @@
+"""Canonical definitions for ship parts and blueprint metadata.
+
+This module centralises the per-part data so that both the rules engine and
+tests share a single source of truth. Only a subset of the Eclipse catalog is
+encoded; it is sufficient for legality checks and can be extended as needed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+@dataclass(frozen=True)
+class ShipPart:
+    """Static data describing a ship part tile."""
+
+    name: str
+    category: str  # computer, shield, cannon, missile, drive, energy, hull
+    weapon_type: Optional[str] = None  # ion, plasma, gauss, antimatter
+    weapon_strength: int = 0
+    missiles: int = 0
+    computer: int = 0
+    shield: int = 0
+    hull: int = 0
+    initiative: int = 0
+    movement: int = 0
+    energy_consumption: int = 0
+    energy_production: int = 0
+    requires_tech: Optional[str] = None
+    slots: int = 1
+
+
+# Primary ship parts referenced by the tests and legality checks. Values are
+# derived from Eclipse 2E, with initiative bonuses simplified for drives.
+SHIP_PARTS: Dict[str, ShipPart] = {
+    "Ion Cannon": ShipPart(
+        name="Ion Cannon",
+        category="cannon",
+        weapon_type="ion",
+        weapon_strength=1,
+    ),
+    "Plasma Cannon": ShipPart(
+        name="Plasma Cannon",
+        category="cannon",
+        weapon_type="plasma",
+        weapon_strength=2,
+        energy_consumption=2,
+        requires_tech="Plasma Cannon",
+    ),
+    "Electron Computer": ShipPart(
+        name="Electron Computer",
+        category="computer",
+        computer=1,
+        energy_consumption=1,
+    ),
+    "Positron Computer": ShipPart(
+        name="Positron Computer",
+        category="computer",
+        computer=2,
+        energy_consumption=2,
+        requires_tech="Positron Computer",
+    ),
+    "Gauss Shield": ShipPart(
+        name="Gauss Shield",
+        category="shield",
+        shield=2,
+        energy_consumption=1,
+        requires_tech="Gauss Shield",
+    ),
+    "Hull": ShipPart(
+        name="Hull",
+        category="hull",
+        hull=1,
+    ),
+    "Improved Hull": ShipPart(
+        name="Improved Hull",
+        category="hull",
+        hull=2,
+        requires_tech="Improved Hull",
+    ),
+    "Nuclear Drive": ShipPart(
+        name="Nuclear Drive",
+        category="drive",
+        movement=1,
+        initiative=1,
+        energy_consumption=1,
+    ),
+    "Fusion Drive": ShipPart(
+        name="Fusion Drive",
+        category="drive",
+        movement=2,
+        initiative=2,
+        energy_consumption=2,
+        requires_tech="Fusion Drive",
+    ),
+    "Antimatter Drive": ShipPart(
+        name="Antimatter Drive",
+        category="drive",
+        movement=3,
+        initiative=3,
+        energy_consumption=3,
+        requires_tech="Antimatter Drive",
+    ),
+    "Nuclear Source": ShipPart(
+        name="Nuclear Source",
+        category="energy",
+        energy_production=3,
+    ),
+    "Fusion Source": ShipPart(
+        name="Fusion Source",
+        category="energy",
+        energy_production=6,
+        requires_tech="Fusion Source",
+    ),
+    "Plasma Missile": ShipPart(
+        name="Plasma Missile",
+        category="missile",
+        missiles=2,
+        initiative=2,
+        energy_consumption=1,
+        requires_tech="Plasma Missile",
+    ),
+}
+
+
+# Blueprint slot limits by ship class (Eclipse 2E reference board).
+SHIP_BLUEPRINT_SLOTS: Dict[str, int] = {
+    "interceptor": 6,
+    "cruiser": 8,
+    "dreadnought": 10,
+    "starbase": 6,
+}
+
+
+MOBILE_SHIPS = {"interceptor", "cruiser", "dreadnought"}
+

--- a/eclipse_ai/state_assembler.py
+++ b/eclipse_ai/state_assembler.py
@@ -87,6 +87,8 @@ def assemble_state(
     if manual_inputs:
         _apply_manual_inputs(gs, manual_inputs)
 
+    _validate_existing_designs(gs)
+
     return gs
 
 # -----------------------------
@@ -197,6 +199,20 @@ def _count_explored_tiles(gs: GameState, player_count: int) -> Counter[int]:
             counts[ring] += additional
 
     return counts
+
+
+def _validate_existing_designs(gs: GameState) -> None:
+    try:
+        from .rules_engine import validate_design
+    except ImportError:
+        return
+
+    for player in gs.players.values():
+        for ship_type, design in (player.ship_designs or {}).items():
+            try:
+                validate_design(player, ship_type, design)
+            except Exception:
+                raise
 
 # -----------------------------
 # Manual inputs

--- a/eclipse_ai/types.py
+++ b/eclipse_ai/types.py
@@ -1,0 +1,71 @@
+"""Shared lightweight dataclasses used across the rules engine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+@dataclass
+class ShipDesign:
+    """A ship blueprint broken down by part category.
+
+    The legacy aggregate fields (computer/shield/etc.) are retained for
+    compatibility with existing evaluation and combat code. Validators are
+    expected to keep them in sync with the underlying part dictionaries.
+    """
+
+    computer: int = 0
+    shield: int = 0
+    initiative: int = 0
+    hull: int = 1
+    cannons: int = 0
+    missiles: int = 0
+    drive: int = 0
+
+    computer_parts: Dict[str, int] = field(default_factory=dict)
+    shield_parts: Dict[str, int] = field(default_factory=dict)
+    cannon_parts: Dict[str, int] = field(default_factory=dict)
+    missile_parts: Dict[str, int] = field(default_factory=dict)
+    drive_parts: Dict[str, int] = field(default_factory=dict)
+    energy_sources: Dict[str, int] = field(default_factory=dict)
+    hull_parts: Dict[str, int] = field(default_factory=dict)
+
+    movement_value: int = 0
+    energy_consumption: int = 0
+    energy_production: int = 0
+
+    def clone(self) -> "ShipDesign":
+        """Deep-copy mutable dictionaries for safe manipulation."""
+
+        return ShipDesign(
+            computer=self.computer,
+            shield=self.shield,
+            initiative=self.initiative,
+            hull=self.hull,
+            cannons=self.cannons,
+            missiles=self.missiles,
+            drive=self.drive,
+            computer_parts=dict(self.computer_parts),
+            shield_parts=dict(self.shield_parts),
+            cannon_parts=dict(self.cannon_parts),
+            missile_parts=dict(self.missile_parts),
+            drive_parts=dict(self.drive_parts),
+            energy_sources=dict(self.energy_sources),
+            hull_parts=dict(self.hull_parts),
+            movement_value=self.movement_value,
+            energy_consumption=self.energy_consumption,
+            energy_production=self.energy_production,
+        )
+
+    # Convenience accessors for compatibility with legacy code that expects a
+    # cannon breakdown by colour or missile count by type.
+    def cannon_breakdown(self) -> Dict[str, int]:
+        return dict(self.cannon_parts)
+
+    def missile_breakdown(self) -> Dict[str, int]:
+        return dict(self.missile_parts)
+
+    def drive_count(self) -> int:
+        return sum(self.drive_parts.values())
+

--- a/tests/test_build_and_design.py
+++ b/tests/test_build_and_design.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import pytest
+
+from eclipse_ai.game_models import (
+    GameState,
+    MapState,
+    PlayerState,
+    Resources,
+    Hex,
+    Pieces,
+)
+from eclipse_ai.rules_engine import (
+    BUILD_COST,
+    FLEET_CAP,
+    RulesViolation,
+    validate_build,
+    validate_design,
+)
+from eclipse_ai.types import ShipDesign
+
+
+def _base_player() -> PlayerState:
+    player = PlayerState(
+        player_id="P1",
+        color="orange",
+        known_techs=[],
+        resources=Resources(money=5, science=5, materials=20),
+    )
+    player.available_components = {
+        "interceptor": 8,
+        "cruiser": 4,
+        "dreadnought": 2,
+        "starbase": 4,
+        "orbital": 4,
+        "monolith": 4,
+    }
+    return player
+
+
+def _state_with_hex(player: PlayerState, hex_id: str = "H1") -> GameState:
+    hx = Hex(
+        id=hex_id,
+        ring=1,
+        pieces={
+            player.player_id: Pieces(ships={}, starbase=0, discs=1, cubes={})
+        },
+    )
+    state = GameState(
+        round=1,
+        active_player=player.player_id,
+        players={player.player_id: player},
+        map=MapState(hexes={hex_id: hx}),
+    )
+    return state
+
+
+def test_upgrade_requires_researched_tech():
+    player = _base_player()
+    design = ShipDesign(
+        computer_parts={"Electron Computer": 1},
+        cannon_parts={"Ion Cannon": 1},
+        drive_parts={"Fusion Drive": 1},
+        energy_sources={"Nuclear Source": 1},
+        hull_parts={"Hull": 1},
+    )
+
+    with pytest.raises(RulesViolation):
+        validate_design(player, "interceptor", design)
+
+    player.known_techs.append("Fusion Drive")
+    validate_design(player, "interceptor", design)
+    assert design.drive == 1
+    assert design.movement_value == 2
+
+
+def test_energy_balance_enforced():
+    player = _base_player()
+    player.known_techs.extend(["Plasma Cannon"])
+    design = ShipDesign(
+        cannon_parts={"Plasma Cannon": 1},
+        drive_parts={"Nuclear Drive": 1},
+        hull_parts={"Hull": 1},
+    )
+
+    with pytest.raises(RulesViolation):
+        validate_design(player, "cruiser", design)
+
+    design.energy_sources["Nuclear Source"] = 1
+    validate_design(player, "cruiser", design)
+    assert design.energy_production >= design.energy_consumption
+
+
+def test_drive_required_mobile_starbase_no_drive():
+    player = _base_player()
+    player.known_techs.extend(["Nuclear Drive", "Starbase"])
+
+    mobile = ShipDesign(hull_parts={"Hull": 1}, energy_sources={"Nuclear Source": 1})
+    with pytest.raises(RulesViolation):
+        validate_design(player, "interceptor", mobile)
+
+    mobile.drive_parts["Nuclear Drive"] = 1
+    validate_design(player, "interceptor", mobile)
+
+    starbase = ShipDesign(
+        cannon_parts={"Ion Cannon": 1},
+        drive_parts={"Nuclear Drive": 1},
+        energy_sources={"Nuclear Source": 1},
+        hull_parts={"Hull": 1},
+    )
+    with pytest.raises(RulesViolation):
+        validate_design(player, "starbase", starbase)
+
+    starbase.drive_parts.clear()
+    validate_design(player, "starbase", starbase)
+
+
+def test_values_cumulative():
+    player = _base_player()
+    player.known_techs.extend(["Fusion Drive"])
+    design = ShipDesign(
+        drive_parts={"Fusion Drive": 2},
+        energy_sources={"Nuclear Source": 2},
+        hull_parts={"Hull": 1},
+    )
+
+    validate_design(player, "cruiser", design)
+    assert design.drive == 2
+    assert design.movement_value == 4
+    assert design.initiative == 4
+    assert design.energy_consumption == 4
+
+
+def test_build_caps():
+    player = _base_player()
+    player.known_techs.append("Starbase")
+    state = _state_with_hex(player)
+    hx = state.map.hexes["H1"]
+    hx.pieces[player.player_id].ships["dreadnought"] = FLEET_CAP["dreadnought"]
+
+    with pytest.raises(RulesViolation):
+        validate_build(player, {"state": state, "ships": {"dreadnought": 1}}, "H1")
+
+    # Fill interceptors to the cap across two hexes
+    hx2 = Hex(
+        id="H2",
+        ring=1,
+        pieces={player.player_id: Pieces(ships={"interceptor": 4}, discs=1)},
+    )
+    state.map.hexes["H2"] = hx2
+    hx.pieces[player.player_id].ships["interceptor"] = 4
+
+    with pytest.raises(RulesViolation):
+        validate_build(player, {"state": state, "ships": {"interceptor": 1}}, "H1")
+
+
+def test_build_costs_and_limit_two_per_action():
+    player = _base_player()
+    state = _state_with_hex(player)
+
+    with pytest.raises(RulesViolation):
+        validate_build(player, {"state": state, "ships": {"interceptor": 3}}, "H1")
+
+    player.resources.materials = BUILD_COST["cruiser"] + BUILD_COST["interceptor"] - 1
+    with pytest.raises(RulesViolation):
+        validate_build(
+            player,
+            {"state": state, "ships": {"cruiser": 1, "interceptor": 1}},
+            "H1",
+        )
+
+    player.resources.materials = BUILD_COST["cruiser"] + BUILD_COST["interceptor"]
+    validate_build(
+        player,
+        {"state": state, "ships": {"cruiser": 1, "interceptor": 1}},
+        "H1",
+    )
+
+
+def test_build_requires_influence_disc_in_hex():
+    player = _base_player()
+    state = _state_with_hex(player)
+    state.map.hexes["H1"].pieces[player.player_id].discs = 0
+
+    with pytest.raises(RulesViolation):
+        validate_build(player, {"state": state, "ships": {"interceptor": 1}}, "H1")
+
+
+def test_structure_prereqs_and_per_hex_limits():
+    player = _base_player()
+    state = _state_with_hex(player)
+    hx = state.map.hexes["H1"]
+
+    with pytest.raises(RulesViolation):
+        validate_build(player, {"state": state, "ships": {"starbase": 1}}, "H1")
+
+    player.known_techs.append("Starbase")
+    validate_build(player, {"state": state, "ships": {"starbase": 1}}, "H1")
+
+    with pytest.raises(RulesViolation):
+        validate_build(player, {"state": state, "structures": {"orbital": 1}}, "H1")
+
+    player.known_techs.append("Orbital")
+    validate_build(player, {"state": state, "structures": {"orbital": 1}}, "H1")
+    hx.orbital = True
+    with pytest.raises(RulesViolation):
+        validate_build(player, {"state": state, "structures": {"orbital": 1}}, "H1")
+
+    with pytest.raises(RulesViolation):
+        validate_build(player, {"state": state, "structures": {"monolith": 1}}, "H1")
+
+    player.known_techs.append("Monolith")
+    validate_build(player, {"state": state, "structures": {"monolith": 1}}, "H1")
+    hx.monolith = True
+    with pytest.raises(RulesViolation):
+        validate_build(player, {"state": state, "structures": {"monolith": 1}}, "H1")
+
+
+def test_component_availability_limits():
+    player = _base_player()
+    player.available_components["dreadnought"] = 0
+    state = _state_with_hex(player)
+
+    with pytest.raises(RulesViolation):
+        validate_build(player, {"state": state, "ships": {"dreadnought": 1}}, "H1")
+
+    player.available_components["dreadnought"] = 2
+    player.available_components["orbital"] = 0
+    with pytest.raises(RulesViolation):
+        validate_build(player, {"state": state, "structures": {"orbital": 1}}, "H1")


### PR DESCRIPTION
## Summary
- define canonical ship part data and richer blueprint structures to support legality checks
- enforce technology gates, energy balance, drive, slot, and capacity rules via new validators
- add regression tests covering upgrade and build restrictions, component limits, and cumulative part effects

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d606a07350832d8a206768943b1cb9