### PR TITLE
Implement research market, pricing, and gating

### DIFF
--- a/data/tech.json
+++ b/data/tech.json
@@ -1,0 +1,67 @@
+[
+  {
+    "id": "plasma_cannon",
+    "name": "Plasma Cannon",
+    "category": "military",
+    "base_cost": 6,
+    "is_rare": false,
+    "grants_parts": ["plasma_cannon"]
+  },
+  {
+    "id": "improved_hull",
+    "name": "Improved Hull",
+    "category": "military",
+    "base_cost": 5,
+    "is_rare": false,
+    "grants_parts": ["improved_hull"]
+  },
+  {
+    "id": "advanced_labs",
+    "name": "Advanced Labs",
+    "category": "grid",
+    "base_cost": 6,
+    "is_rare": false,
+    "immediate_effect": {"science": 2}
+  },
+  {
+    "id": "nanorobots",
+    "name": "Nanorobots",
+    "category": "nano",
+    "base_cost": 5,
+    "is_rare": false,
+    "immediate_effect": {"materials": 2}
+  },
+  {
+    "id": "gauss_shield",
+    "name": "Gauss Shield",
+    "category": "military",
+    "base_cost": 7,
+    "is_rare": false,
+    "grants_parts": ["gauss_shield"]
+  },
+  {
+    "id": "starbase_construction",
+    "name": "Starbase Construction",
+    "category": "grid",
+    "base_cost": 5,
+    "is_rare": false,
+    "grants_structures": ["starbase"]
+  },
+  {
+    "id": "zero_point_source",
+    "name": "Zero-Point Source",
+    "category": "rare",
+    "base_cost": 8,
+    "is_rare": true,
+    "immediate_effect": {"money": 4}
+  },
+  {
+    "id": "quantum_grid",
+    "name": "Quantum Grid",
+    "category": "grid",
+    "base_cost": 7,
+    "is_rare": true,
+    "grants_parts": ["quantum_grid"],
+    "grants_structures": ["quantum_generator"]
+  }
+]

--- a/eclipse_ai/evaluator.py
+++ b/eclipse_ai/evaluator.py
@@ -44,7 +44,8 @@ def _score_explore(state: GameState, pid: str, payload: Dict[str, Any]) -> Score
 
     you = state.players.get(pid) if state.players else None
     draws = int(payload.get("draws", 1))
-    wormhole_gen = ("Wormhole Generator" in (you.known_techs if you else [])) or bool(payload.get("wormhole_generator", False))
+    owned = you.owned_tech_ids if you and you.owned_tech_ids else set()
+    wormhole_gen = ("wormhole_generator" in owned) or bool(payload.get("wormhole_generator", False))
     discs_available = int(payload.get("discs_available", 1))
     colony_ships = dict(payload.get("colony_ships", {"yellow":1,"blue":1,"brown":1,"wild":0}))
     p_connect_default = float(payload.get("p_connect_default", 0.70))

--- a/eclipse_ai/rules_engine.py
+++ b/eclipse_ai/rules_engine.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, field
 from typing import List, Dict, Any, Optional, Tuple
 
 from .game_models import GameState, Action, ActionType, PlayerState, Hex, Planet, Pieces, Resources, ShipDesign
+from .technology import discounted_cost, can_research, load_tech_definitions
 
 # =============================
 # Config
@@ -88,19 +89,23 @@ def _enum_explore(state: GameState, you: PlayerState) -> List[Action]:
 
 def _enum_research(state: GameState, you: PlayerState) -> List[Action]:
     out: List[Action] = []
-    avail = list(state.tech_display.available) if state.tech_display else []
-    known = set(you.known_techs or [])
-    science = you.resources.science if you.resources else 0
+    if not state.tech_definitions:
+        state.tech_definitions = load_tech_definitions()
+    avail = list(state.market)
+    known = set(you.owned_tech_ids or set())
+    science = you.science
     # Sort by a simple preference: combat techs, mobility, economy
     priority = sorted(avail, key=_tech_priority_key, reverse=True)
     for tech in priority:
         if tech in known:
             continue
-        cost = _approx_tech_cost(tech, len(known))
-        if science >= cost:
+        tech_obj = state.tech_definitions.get(tech)
+        if tech_obj is None:
+            continue
+        cost = discounted_cost(you, tech_obj)
+        if science >= cost and can_research(state, you, tech):
             out.append(Action(ActionType.RESEARCH, {"tech": tech, "approx_cost": cost}))
-        # propose one stretch pick even if not fully affordable (you might have discounts)
-        elif len(out) < 1 and science >= max(1, cost - 1):
+        elif len(out) < 1 and science + 1 >= cost and can_research(state, you, tech):
             out.append(Action(ActionType.RESEARCH, {"tech": tech, "approx_cost": cost, "note": "stretch"}))
         if len(out) >= 5:
             break

--- a/eclipse_ai/search_policy.py
+++ b/eclipse_ai/search_policy.py
@@ -6,6 +6,7 @@ import math, random, copy
 from .game_models import GameState, Action, Score, ActionType, PlayerState, Hex, Pieces, Planet, ShipDesign
 from .rules_engine import legal_actions
 from .evaluator import evaluate_action
+from .technology import do_research, ResearchError, load_tech_definitions
 
 # =============================
 # Public data structures
@@ -256,11 +257,13 @@ def _forward_model(state: GameState, pid: str, action: Action) -> GameState:
 
     if t == ActionType.RESEARCH:
         tech = str(p.get("tech", ""))
-        if tech and tech not in you.known_techs:
-            you.known_techs.append(tech)
-            # subtract rough science cost
-            cost = max(2, _SCIENCE_COST_BASE + min(2, len(you.known_techs)//4))
-            you.resources.science = max(0, you.resources.science - cost)
+        if tech:
+            if not s.tech_definitions:
+                s.tech_definitions = load_tech_definitions()
+            try:
+                do_research(s, you, tech)
+            except ResearchError:
+                pass
         return s
 
     if t == ActionType.BUILD:

--- a/eclipse_ai/state_assembler.py
+++ b/eclipse_ai/state_assembler.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from copy import deepcopy
 
 from .game_models import GameState, PlayerState, Resources, MapState, TechDisplay, Pieces
+from .technology import load_tech_definitions
 
 _ROUND_EXPLORED_FRACTION = 0.33
 
@@ -72,6 +73,8 @@ def assemble_state(
       - manual_inputs can be nested dicts or dot-path overrides (e.g., "players.you.resources.money": 12).
     """
     gs = deepcopy(prior_state) if prior_state is not None else _default_state()
+    if not gs.tech_definitions:
+        gs.tech_definitions = load_tech_definitions()
     # Update core
     gs.map = map_state
     gs.tech_display = tech_display
@@ -83,9 +86,15 @@ def assemble_state(
     _ensure_bags_for_rings(gs)
     _populate_explore_bags(gs)
 
+    # Ensure player tech state derived from any known tech lists remains consistent.
+    for p in gs.players.values():
+        _initialise_player_state(p, gs.tech_definitions)
+
     # Apply manual inputs
     if manual_inputs:
         _apply_manual_inputs(gs, manual_inputs)
+        for p in gs.players.values():
+            _initialise_player_state(p, gs.tech_definitions)
 
     return gs
 
@@ -115,10 +124,13 @@ def apply_overrides(state: GameState, manual_inputs: Dict[str, Any]) -> GameStat
 
 def _default_state() -> GameState:
     players = {
-        "you": PlayerState(player_id="you", color="orange", resources=Resources(10,7,6)),
-        "blue": PlayerState(player_id="blue", color="blue", resources=Resources(8,6,7))
+        "you": PlayerState(player_id="you", color="orange", resources=Resources(10,7,6), influence_discs=3),
+        "blue": PlayerState(player_id="blue", color="blue", resources=Resources(8,6,7), influence_discs=3)
     }
     gs = GameState(round=6, active_player="you", players=players, map=MapState(), tech_display=TechDisplay())
+    for p in gs.players.values():
+        _initialise_player_state(p, gs.tech_definitions)
+    gs.tech_definitions = load_tech_definitions()
     # Provide a minimal example bag so exploration math runs. Caller should replace with real counts.
     gs.bags = {"R2": {"ancient":3, "monolith":1, "money2":4, "science2":4, "materials2":4}}
     return gs
@@ -131,7 +143,9 @@ def _reconcile_players_from_map(gs: GameState) -> None:
             if pid not in present:
                 present.add(pid)
                 # Neutral defaults
-                gs.players[pid] = PlayerState(player_id=pid, color=pid, resources=Resources(6,6,6))
+                new_player = PlayerState(player_id=pid, color=pid, resources=Resources(6,6,6))
+                _initialise_player_state(new_player, gs.tech_definitions)
+                gs.players[pid] = new_player
             # Ensure Pieces data structure is well-formed
             p = hx.pieces[pid]
             if p.cubes is None:
@@ -197,6 +211,40 @@ def _count_explored_tiles(gs: GameState, player_count: int) -> Counter[int]:
             counts[ring] += additional
 
     return counts
+
+
+def _initialise_player_state(player: PlayerState, definitions: Optional[Dict[str, "Tech"]]=None) -> None:
+    from .technology import load_tech_definitions  # local import to avoid cycles
+
+    tech_defs = definitions or load_tech_definitions()
+    player.science = int(player.science or player.resources.science)
+    if player.influence_discs is None:
+        player.influence_discs = 0
+    player.influence_discs = int(player.influence_discs)
+    player.owned_tech_ids = set(player.owned_tech_ids or set())
+    player.tech_count_by_category = dict(player.tech_count_by_category or {})
+    player.unlocked_parts = set(player.unlocked_parts or set())
+    player.unlocked_structures = set(player.unlocked_structures or set())
+
+    name_to_id = {t.name.lower(): tid for tid, t in tech_defs.items()}
+    for entry in list(player.known_techs or []):
+        tid = name_to_id.get(entry.lower())
+        if tid:
+            player.owned_tech_ids.add(tid)
+
+    # Recompute caches from owned techs
+    player.tech_count_by_category.clear()
+    player.unlocked_parts.clear()
+    player.unlocked_structures.clear()
+    for tid in list(player.owned_tech_ids):
+        tech = tech_defs.get(tid)
+        if not tech:
+            continue
+        player.tech_count_by_category[tech.category] = player.tech_count_by_category.get(tech.category, 0) + 1
+        player.unlocked_parts.update(tech.grants_parts)
+        player.unlocked_structures.update(tech.grants_structures)
+        if tech.name not in player.known_techs:
+            player.known_techs.append(tech.name)
 
 # -----------------------------
 # Manual inputs

--- a/eclipse_ai/technology.py
+++ b/eclipse_ai/technology.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+from .game_models import GameState, PlayerState, Tech
+
+
+class ResearchError(RuntimeError):
+    """Raised when a research action is illegal."""
+
+
+_TECH_DATA_CACHE: Optional[Dict[str, Tech]] = None
+
+
+MARKET_SIZES_BY_PLAYER_COUNT = {
+    2: 4,
+    3: 5,
+    4: 6,
+    5: 7,
+    6: 8,
+}
+
+
+def _tech_data_path() -> Path:
+    return Path(__file__).resolve().parent.parent / "data" / "tech.json"
+
+
+def load_tech_definitions() -> Dict[str, Tech]:
+    """Load the canonical tech definitions from disk (cached)."""
+
+    global _TECH_DATA_CACHE
+    if _TECH_DATA_CACHE is not None:
+        return _TECH_DATA_CACHE
+
+    path = _tech_data_path()
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            raw = json.load(handle)
+    except FileNotFoundError as exc:  # pragma: no cover - configuration error
+        raise ResearchError(f"technology data file missing: {path}") from exc
+
+    catalog: Dict[str, Tech] = {}
+    for entry in raw:
+        tech = Tech(
+            id=entry["id"],
+            name=entry.get("name", entry["id"]),
+            category=entry.get("category", "grid"),
+            base_cost=int(entry.get("base_cost", 4)),
+            is_rare=bool(entry.get("is_rare", False)),
+            grants_parts=list(entry.get("grants_parts", [])),
+            grants_structures=list(entry.get("grants_structures", [])),
+            immediate_effect=entry.get("immediate_effect"),
+        )
+        catalog[tech.id] = tech
+
+    _TECH_DATA_CACHE = catalog
+    return catalog
+
+
+def discounted_cost(player: PlayerState, tech: Tech) -> int:
+    """Return the Science cost after applying category discounts."""
+
+    discounts = player.tech_count_by_category.get(tech.category, 0)
+    return max(1, tech.base_cost - discounts)
+
+
+def _assert_phase_is_action(state: GameState) -> None:
+    if state.phase.lower() != "action":
+        raise ResearchError("cannot research during Reaction")
+
+
+def _assert_disc_available(player: PlayerState) -> None:
+    if player.influence_discs <= 0:
+        raise ResearchError("no influence discs available for Research")
+
+
+def _market_size_for_players(state: GameState) -> int:
+    count = max(2, len(state.players) or 2)
+    return MARKET_SIZES_BY_PLAYER_COUNT.get(count, 8)
+
+
+def _market_without_duplicates(state: GameState, taken_rare_ids: Set[str]) -> List[str]:
+    """Return the market list filtered for duplicates and illegal rares."""
+
+    seen: Set[str] = set()
+    filtered: List[str] = []
+    for tech_id in state.market:
+        if tech_id in seen:
+            continue
+        tech = state.tech_definitions.get(tech_id)
+        if tech is None:
+            continue
+        if tech.is_rare and tech_id in taken_rare_ids:
+            continue
+        seen.add(tech_id)
+        filtered.append(tech_id)
+    return filtered
+
+
+def cleanup_refresh_market(state: GameState) -> None:
+    """Refill the face-up market from the draw bags during Cleanup."""
+
+    if not state.tech_definitions:
+        state.tech_definitions = load_tech_definitions()
+
+    taken_rares: Set[str] = set()
+    for player in state.players.values():
+        for tech_id in player.owned_tech_ids:
+            tech = state.tech_definitions.get(tech_id)
+            if tech and tech.is_rare:
+                taken_rares.add(tech_id)
+
+    state.market = _market_without_duplicates(state, taken_rares)
+    target = _market_size_for_players(state)
+    if len(state.market) >= target:
+        state.market = state.market[:target]
+        return
+
+    # Draw from bags in key order (tiers typically I < II < III).
+    for bag_name in sorted(state.tech_bags.keys()):
+        bag = state.tech_bags[bag_name]
+        draw_index = 0
+        while draw_index < len(bag) and len(state.market) < target:
+            tech_id = bag[draw_index]
+            tech = state.tech_definitions.get(tech_id)
+            draw_index += 1
+            if tech is None:
+                continue
+            if tech.is_rare and tech_id in taken_rares:
+                continue
+            if tech_id in state.market:
+                continue
+            state.market.append(tech_id)
+
+        # Remove the tiles that were effectively drawn.
+        if draw_index > 0:
+            del bag[:draw_index]
+        if len(state.market) >= target:
+            break
+
+
+def can_research(state: GameState, player: PlayerState, tech_id: str) -> bool:
+    try:
+        validate_research(state, player, tech_id)
+        return True
+    except ResearchError:
+        return False
+
+
+def validate_research(state: GameState, player: PlayerState, tech_id: str) -> None:
+    """Raise ResearchError if the research action is illegal."""
+
+    if not state.tech_definitions:
+        state.tech_definitions = load_tech_definitions()
+
+    _assert_phase_is_action(state)
+    _assert_disc_available(player)
+
+    if tech_id not in state.market:
+        raise ResearchError("tech not available in market")
+
+    tech = state.tech_definitions.get(tech_id)
+    if tech is None:
+        raise ResearchError("unknown technology id")
+
+    if tech.is_rare and tech_id in player.owned_tech_ids:
+        raise ResearchError("Rare tech already taken")
+
+    if tech_id in player.owned_tech_ids:
+        raise ResearchError("technology already owned")
+
+    if tech.is_rare:
+        for other in state.players.values():
+            if other is player:
+                continue
+            if tech_id in other.owned_tech_ids:
+                raise ResearchError("Rare tech already taken")
+
+    cost = discounted_cost(player, tech)
+    if player.science < cost:
+        raise ResearchError("insufficient Science after discount")
+
+
+def _apply_immediate_effect(state: GameState, player: PlayerState, tech: Tech) -> None:
+    effect = tech.immediate_effect or {}
+    if not isinstance(effect, dict):
+        return
+
+    if effect.get("science"):
+        delta = int(effect["science"])
+        player.science += delta
+        player.resources.science = max(0, player.science)
+    if effect.get("money"):
+        delta = int(effect["money"])
+        player.resources.money += delta
+    if effect.get("materials"):
+        delta = int(effect["materials"])
+        player.resources.materials += delta
+
+
+def _recompute_category_cache(player: PlayerState, definitions: Dict[str, Tech]) -> None:
+    counts: Dict[str, int] = {}
+    for tech_id in player.owned_tech_ids:
+        tech = definitions.get(tech_id)
+        if tech is None:
+            continue
+        counts[tech.category] = counts.get(tech.category, 0) + 1
+    player.tech_count_by_category = counts
+
+
+def _unlock_from_tech(player: PlayerState, tech: Tech) -> None:
+    if tech.grants_parts:
+        player.unlocked_parts.update(tech.grants_parts)
+    if tech.grants_structures:
+        player.unlocked_structures.update(tech.grants_structures)
+
+
+def do_research(state: GameState, player: PlayerState, tech_id: str) -> None:
+    """Execute the research action for the player."""
+
+    validate_research(state, player, tech_id)
+    tech = state.tech_definitions[tech_id]
+    cost = discounted_cost(player, tech)
+
+    player.influence_discs -= 1
+    player.science -= cost
+    player.resources.science = max(0, player.science)
+
+    state.market = [tid for tid in state.market if tid != tech_id]
+    player.owned_tech_ids.add(tech_id)
+    if tech.name not in player.known_techs:
+        player.known_techs.append(tech.name)
+    _unlock_from_tech(player, tech)
+    _recompute_category_cache(player, state.tech_definitions)
+    _apply_immediate_effect(state, player, tech)
+
+
+def ensure_structure_allowed(player: PlayerState, structure: str) -> None:
+    if structure not in player.unlocked_structures:
+        raise ResearchError("required technology not owned")
+
+
+def ensure_part_allowed(player: PlayerState, part: str) -> None:
+    if part not in player.unlocked_parts:
+        raise ResearchError("required technology not owned")

--- a/tests/test_technology.py
+++ b/tests/test_technology.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import pytest
+
+from eclipse_ai.game_models import GameState, PlayerState, Resources, MapState
+from eclipse_ai.technology import (
+    ResearchError,
+    can_research,
+    cleanup_refresh_market,
+    discounted_cost,
+    do_research,
+    ensure_part_allowed,
+    ensure_structure_allowed,
+    load_tech_definitions,
+    MARKET_SIZES_BY_PLAYER_COUNT,
+)
+
+
+def _make_state(player_count: int = 1) -> GameState:
+    defs = load_tech_definitions()
+    players = {}
+    for idx in range(player_count):
+        pid = f"P{idx + 1}"
+        resources = Resources(money=5, science=10, materials=5)
+        players[pid] = PlayerState(
+            player_id=pid,
+            color="orange",
+            resources=resources,
+            science=resources.science,
+            influence_discs=3,
+        )
+        players[pid].tech_count_by_category = {}
+        players[pid].owned_tech_ids = set()
+        players[pid].unlocked_parts = set()
+        players[pid].unlocked_structures = set()
+    return GameState(
+        round=1,
+        active_player="P1",
+        phase="action",
+        players=players,
+        map=MapState(),
+        tech_bags={},
+        market=[],
+        tech_definitions=defs,
+    )
+
+
+def test_research_spends_disc_and_science():
+    state = _make_state()
+    player = state.players["P1"]
+    state.market = ["advanced_labs"]
+    player.science = 6
+    player.resources.science = 6
+    player.influence_discs = 2
+
+    do_research(state, player, "advanced_labs")
+
+    assert player.influence_discs == 1
+    # pay 6, immediate effect refunds +2 science
+    assert player.science == 2
+    assert "advanced_labs" in player.owned_tech_ids
+
+
+def test_category_discount_applies_only_within_category():
+    state = _make_state()
+    player = state.players["P1"]
+    player.owned_tech_ids.update({"plasma_cannon", "improved_hull"})
+    player.tech_count_by_category = {"military": 2}
+    player.science = 10
+    player.resources.science = 10
+
+    defs = state.tech_definitions
+    military_cost = discounted_cost(player, defs["gauss_shield"])
+    grid_cost = discounted_cost(player, defs["advanced_labs"])
+
+    assert military_cost == 5
+    assert grid_cost == defs["advanced_labs"].base_cost
+
+
+def test_no_research_as_reaction():
+    state = _make_state()
+    player = state.players["P1"]
+    state.market = ["nanorobots"]
+    player.science = 5
+    player.resources.science = 5
+    state.phase = "reaction"
+
+    assert not can_research(state, player, "nanorobots")
+    with pytest.raises(ResearchError, match="cannot research during Reaction"):
+        do_research(state, player, "nanorobots")
+
+
+def test_rare_uniqueness_and_starting_rare():
+    state = _make_state(player_count=2)
+    p1 = state.players["P1"]
+    p2 = state.players["P2"]
+    p1.owned_tech_ids.add("zero_point_source")
+    p1.tech_count_by_category = {"rare": 1}
+    state.market = ["zero_point_source"]
+    state.tech_bags = {"III": ["zero_point_source", "quantum_grid"]}
+
+    cleanup_refresh_market(state)
+
+    assert "zero_point_source" not in state.market
+    assert "zero_point_source" not in state.tech_bags["III"]
+
+    state.market.append("quantum_grid")
+    p2.science = 8
+    p2.resources.science = 8
+    p2.influence_discs = 2
+    do_research(state, p2, "quantum_grid")
+
+    assert "quantum_grid" not in state.market
+    assert all("quantum_grid" not in bag for bag in state.tech_bags.values())
+    with pytest.raises(ResearchError, match="tech not available in market"):
+        do_research(state, p1, "zero_point_source")
+
+
+def test_grants_parts_and_structures_gated():
+    state = _make_state()
+    player = state.players["P1"]
+
+    with pytest.raises(ResearchError, match="required technology not owned"):
+        ensure_structure_allowed(player, "starbase")
+    with pytest.raises(ResearchError, match="required technology not owned"):
+        ensure_part_allowed(player, "plasma_cannon")
+
+    state.market = ["starbase_construction", "plasma_cannon"]
+    player.science = 12
+    player.resources.science = 12
+
+    do_research(state, player, "starbase_construction")
+    ensure_structure_allowed(player, "starbase")
+
+    state.market.append("plasma_cannon")
+    do_research(state, player, "plasma_cannon")
+    ensure_part_allowed(player, "plasma_cannon")
+
+
+def test_cleanup_refills_market_only_in_cleanup():
+    state = _make_state(player_count=2)
+    player = state.players["P1"]
+    player.science = 8
+    player.resources.science = 8
+    player.influence_discs = 2
+    state.market = ["plasma_cannon", "advanced_labs", "nanorobots"]
+    state.tech_bags = {"I": ["gauss_shield", "improved_hull"]}
+
+    do_research(state, player, "plasma_cannon")
+    assert state.market == ["advanced_labs", "nanorobots"]
+
+    cleanup_refresh_market(state)
+    target = MARKET_SIZES_BY_PLAYER_COUNT[len(state.players)]
+    assert len(state.market) <= target
+    assert "gauss_shield" in state.market or "improved_hull" in state.market


### PR DESCRIPTION
## Summary
- add a structured technology catalogue and research manager covering pricing, discounts, and rarity constraints
- extend the game and player models plus state assembly to track markets, science, and unlocked parts/structures
- update research heuristics and add targeted tests for research flow, rare handling, and gating requirements

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d607aff268832d852dba4afca8944a