### PR TITLE
Add species registry and Octantis evolution details

### DIFF
--- a/eclipse_ai/__init__.py
+++ b/eclipse_ai/__init__.py
@@ -19,6 +19,7 @@ from .game_models import (
 from .main import recommend
 from .search_policy import MCTSPlanner, Plan, PlanStep
 from .overlay import plan_overlays
+from .species_data import SpeciesConfig, get_species, all_species, get_registry
 from .uncertainty import BeliefState, DiscreteHMM, TileParticleFilter, TileParticle
 
 __all__ = [
@@ -43,5 +44,9 @@ __all__ = [
     "DiscreteHMM",
     "TileParticleFilter",
     "TileParticle",
+    "SpeciesConfig",
+    "get_species",
+    "all_species",
+    "get_registry",
     "__version__",
 ]

--- a/eclipse_ai/data/species.json
+++ b/eclipse_ai/data/species.json
@@ -1,0 +1,332 @@
+{
+  "_meta": {
+    "schema": "eclipse.species.config.v1",
+    "sources": [
+      "Eclipse Second Dawn rulebook",
+      "Rise of the Ancients",
+      "Shadows of the Rift"
+    ],
+    "notes": "Trade rate is expressed as trade goods required -> resources gained. starting_storage uses resource track capacity pips shown on faction boards."
+  },
+  "terrans": {
+    "name": "Terrans",
+    "expansion": "base",
+    "starting_sector": 101,
+    "trade_rate": {"goods": 3, "resources": 1},
+    "starting_storage": {"money": 3, "science": 3, "materials": 3},
+    "starting_resources": {"money": 2, "science": 2, "materials": 2},
+    "starting_colonies": {"home": {"money": 1, "science": 1, "materials": 1}},
+    "starting_ships": {"home": {"interceptor": 2, "cruiser": 0, "dreadnought": 0, "starbase": 0}},
+    "starting_structures": {"home": {"orbital": 0, "monolith": 0}},
+    "starting_techs": [],
+    "starting_discs_delta": 0,
+    "colony_ships": 3,
+    "action_overrides": {},
+    "build_limits": {},
+    "vp_bonuses": {},
+    "cannot_build": [],
+    "notes": [
+      "Baseline faction shared by Terran subfactions (Directorate, Federation, Union, Republic)."
+    ]
+  },
+  "eridani": {
+    "name": "Eridani Empire",
+    "expansion": "base",
+    "starting_sector": 224,
+    "trade_rate": {"goods": 3, "resources": 1},
+    "starting_storage": {"money": 4, "science": 2, "materials": 3},
+    "starting_resources": {"money": 0, "science": 0, "materials": 0},
+    "starting_colonies": {"home": {"money": 1, "science": 1, "materials": 1}},
+    "starting_ships": {"home": {"interceptor": 1, "cruiser": 1, "dreadnought": 0, "starbase": 0}},
+    "starting_structures": {"home": {"orbital": 0, "monolith": 0}},
+    "starting_techs": ["Gauss Shield", "Fusion Drive", "Plasma Cannon"],
+    "starting_discs_delta": -2,
+    "colony_ships": 3,
+    "action_overrides": {},
+    "build_limits": {},
+    "vp_bonuses": {},
+    "cannot_build": [],
+    "notes": [
+      "Begins with two fewer influence discs and an advanced cruiser focus."
+    ]
+  },
+  "hydran": {
+    "name": "Hydran Progress",
+    "expansion": "base",
+    "starting_sector": 226,
+    "trade_rate": {"goods": 3, "resources": 1},
+    "starting_storage": {"money": 2, "science": 4, "materials": 3},
+    "starting_resources": {"money": 0, "science": 3, "materials": 0},
+    "starting_colonies": {"home": {"science": 2, "materials": 1}},
+    "starting_ships": {"home": {"interceptor": 2, "cruiser": 0, "dreadnought": 0, "starbase": 0}},
+    "starting_structures": {"home": {"orbital": 0, "monolith": 0}},
+    "starting_techs": ["Advanced Labs"],
+    "starting_discs_delta": 0,
+    "colony_ships": 3,
+    "action_overrides": {"research_per_action": 2},
+    "build_limits": {},
+    "vp_bonuses": {},
+    "cannot_build": [],
+    "notes": [
+      "Research focused economy. Hydran Evolution tiles integrate with Octantis Evolution rules when that module is active."
+    ]
+  },
+  "planta": {
+    "name": "Planta",
+    "expansion": "base",
+    "starting_sector": 228,
+    "trade_rate": {"goods": 3, "resources": 1},
+    "starting_storage": {"money": 3, "science": 2, "materials": 4},
+    "starting_resources": {"money": 0, "science": 0, "materials": 3},
+    "starting_colonies": {"home": {"materials": 2}},
+    "starting_ships": {"home": {"interceptor": 1, "cruiser": 0, "dreadnought": 0, "starbase": 0}},
+    "starting_structures": {"home": {"orbital": 0, "monolith": 0}},
+    "starting_techs": ["Starbase"],
+    "starting_discs_delta": 0,
+    "colony_ships": 3,
+    "action_overrides": {"explores_per_action": 2},
+    "build_limits": {},
+    "vp_bonuses": {"hex_control": 1},
+    "cannot_build": [],
+    "notes": [
+      "Root Network: treat controlled hexes as adjacent for movement and influence.",
+      "In two-player games Planta is considered stronger and often recommended to avoid for balance."
+    ]
+  },
+  "mechanema": {
+    "name": "Mechanema",
+    "expansion": "base",
+    "starting_sector": 227,
+    "trade_rate": {"goods": 3, "resources": 1},
+    "starting_storage": {"money": 3, "science": 4, "materials": 2},
+    "starting_resources": {"money": 0, "science": 2, "materials": 1},
+    "starting_colonies": {"home": {"science": 2, "materials": 1}},
+    "starting_ships": {"home": {"interceptor": 2, "cruiser": 0, "dreadnought": 0, "starbase": 0}},
+    "starting_structures": {"home": {"orbital": 0, "monolith": 0}},
+    "starting_techs": ["Positron Computer"],
+    "starting_discs_delta": 0,
+    "colony_ships": 3,
+    "action_overrides": {"upgrade_parts_per_action": 3},
+    "build_limits": {"build_discount": "mechanema"},
+    "vp_bonuses": {},
+    "cannot_build": [],
+    "notes": [
+      "May upgrade up to three ship parts per Upgrade action."
+    ]
+  },
+  "orion": {
+    "name": "Orion Hegemony",
+    "expansion": "base",
+    "starting_sector": 230,
+    "trade_rate": {"goods": 3, "resources": 1},
+    "starting_storage": {"money": 4, "science": 2, "materials": 3},
+    "starting_resources": {"money": 2, "science": 1, "materials": 2},
+    "starting_colonies": {"home": {"money": 1, "science": 1, "materials": 1}},
+    "starting_ships": {"home": {"interceptor": 0, "cruiser": 1, "dreadnought": 0, "starbase": 0}},
+    "starting_structures": {"home": {"orbital": 0, "monolith": 0}},
+    "starting_techs": ["Neutron Bombs", "Gauss Shield"],
+    "starting_discs_delta": 0,
+    "colony_ships": 3,
+    "action_overrides": {},
+    "build_limits": {"builds_per_action": 3},
+    "vp_bonuses": {},
+    "cannot_build": [],
+    "notes": [
+      "Aggressive faction with cheaper build actions (up to three ships/structures per action)."
+    ]
+  },
+  "draco": {
+    "name": "Descendants of Draco",
+    "expansion": "base",
+    "starting_sector": 229,
+    "trade_rate": {"goods": 3, "resources": 1},
+    "starting_storage": {"money": 3, "science": 3, "materials": 3},
+    "starting_resources": {"money": 1, "science": 1, "materials": 1},
+    "starting_colonies": {"home": {"money": 1, "science": 1, "materials": 1}},
+    "starting_ships": {"home": {"interceptor": 1, "cruiser": 0, "dreadnought": 0, "starbase": 0}},
+    "starting_structures": {"home": {"orbital": 0, "monolith": 0}},
+    "starting_techs": [],
+    "starting_discs_delta": 0,
+    "colony_ships": 3,
+    "action_overrides": {},
+    "build_limits": {},
+    "vp_bonuses": {"ancients_remaining": 1},
+    "cannot_build": [],
+    "notes": [
+      "May share hexes with Ancients without combat and cannot take their discoveries.",
+      "Considered strong in two-player games; often omitted for balance."
+    ]
+  },
+  "rho_indi": {
+    "name": "Rho Indi Syndicate",
+    "expansion": "rise",
+    "starting_sector": 237,
+    "trade_rate": {"goods": 3, "resources": 2},
+    "starting_storage": {"money": 4, "science": 2, "materials": 3},
+    "starting_resources": {"money": 3, "science": 0, "materials": 0},
+    "starting_colonies": {"home": {"money": 2}},
+    "starting_ships": {"home": {"interceptor": 2, "cruiser": 0, "dreadnought": 0, "starbase": 0}},
+    "starting_structures": {"home": {"orbital": 0, "monolith": 0}},
+    "starting_techs": ["Gluon Computer"],
+    "starting_discs_delta": 0,
+    "colony_ships": 3,
+    "action_overrides": {},
+    "build_limits": {},
+    "vp_bonuses": {},
+    "cannot_build": [],
+    "notes": [
+      "Pillage: gain 1 money when drawing reputation for winning battles."
+    ]
+  },
+  "enlightened": {
+    "name": "Enlightened of Lyra",
+    "expansion": "rise",
+    "starting_sector": 238,
+    "trade_rate": {"goods": 3, "resources": 1},
+    "starting_storage": {"money": 3, "science": 4, "materials": 2},
+    "starting_resources": {"money": 1, "science": 2, "materials": 1},
+    "starting_colonies": {"home": {"science": 2, "materials": 1}},
+    "starting_ships": {"home": {"interceptor": 1, "cruiser": 0, "dreadnought": 0, "starbase": 0}},
+    "starting_structures": {"home": {"orbital": 0, "monolith": 0, "shrine": 0}},
+    "starting_techs": [],
+    "starting_discs_delta": 0,
+    "colony_ships": 2,
+    "action_overrides": {"move_ship_activations": 4},
+    "build_limits": {},
+    "vp_bonuses": {"shrine_vp": 1},
+    "cannot_build": [],
+    "notes": [
+      "May reroll combat dice by flipping Colony Ships and ignore Traitor penalty.",
+      "Starts with two colony ships instead of three."
+    ]
+  },
+  "exiles": {
+    "name": "The Exiles",
+    "expansion": "rise",
+    "starting_sector": 239,
+    "trade_rate": {"goods": 3, "resources": 1},
+    "starting_storage": {"money": 3, "science": 2, "materials": 4},
+    "starting_resources": {"money": 2, "science": 0, "materials": 2},
+    "starting_colonies": {"home": {"money": 1, "materials": 1}},
+    "starting_ships": {"home": {"interceptor": 1, "cruiser": 0, "dreadnought": 0, "starbase": 0}},
+    "starting_structures": {"home": {"orbital": 1, "monolith": 0}},
+    "starting_techs": ["Cloaking Device", "Orbital"],
+    "starting_discs_delta": 0,
+    "colony_ships": 3,
+    "action_overrides": {},
+    "build_limits": {},
+    "vp_bonuses": {},
+    "cannot_build": ["starbase"],
+    "notes": [
+      "Orbitals count as ships without drives. When destroyed an opponent draws reputation.",
+      "Cannot build Starbases."
+    ]
+  },
+  "magellan": {
+    "name": "Magellan",
+    "expansion": "rise",
+    "starting_sector": 234,
+    "trade_rate": {"goods": 3, "resources": 1},
+    "starting_storage": {"money": 3, "science": 2, "materials": 4},
+    "starting_resources": {"money": 0, "science": 0, "materials": 3},
+    "starting_colonies": {"home": {"materials": 2}},
+    "starting_ships": {"home": {"interceptor": 2, "cruiser": 0, "dreadnought": 0, "starbase": 0}},
+    "starting_structures": {"home": {"orbital": 0, "monolith": 0}},
+    "starting_techs": ["Fusion Source"],
+    "starting_discs_delta": 0,
+    "colony_ships": 3,
+    "action_overrides": {},
+    "build_limits": {},
+    "vp_bonuses": {"orbital_vp": 1},
+    "cannot_build": [],
+    "notes": [
+      "Variants: Keepers, Sentinels, Wardens. May flip a Colony Ship at any time for a resource of choice."
+    ]
+  },
+  "shapers": {
+    "name": "Shapers of Dorado",
+    "expansion": "sotr",
+    "starting_sector": 401,
+    "trade_rate": {"goods": 3, "resources": 1},
+    "starting_storage": {"money": 3, "science": 4, "materials": 2},
+    "starting_resources": {"money": 1, "science": 2, "materials": 1},
+    "starting_colonies": {"home": {"science": 2, "materials": 1}},
+    "starting_ships": {"home": {"interceptor": 1, "cruiser": 0, "dreadnought": 0, "starbase": 0}},
+    "starting_structures": {"home": {"orbital": 0, "monolith": 0}},
+    "starting_techs": ["Soliton Cannon"],
+    "starting_discs_delta": 0,
+    "colony_ships": 3,
+    "action_overrides": {},
+    "build_limits": {},
+    "vp_bonuses": {},
+    "cannot_build": [],
+    "notes": [
+      "Starts with Soliton Cannon technology and access to Rift weapons."
+    ]
+  },
+  "pyxis": {
+    "name": "Pyxis Unity",
+    "expansion": "sotr",
+    "starting_sector": 402,
+    "trade_rate": {"goods": 3, "resources": 1},
+    "starting_storage": {"money": 3, "science": 3, "materials": 4},
+    "starting_resources": {"money": 1, "science": 1, "materials": 2},
+    "starting_colonies": {"home": {"money": 1, "materials": 1}},
+    "starting_ships": {"home": {"interceptor": 1, "cruiser": 0, "dreadnought": 0, "starbase": 0}},
+    "starting_structures": {"home": {"orbital": 0, "monolith": 0}},
+    "starting_techs": ["Transmatter"],
+    "starting_discs_delta": 0,
+    "colony_ships": 3,
+    "action_overrides": {},
+    "build_limits": {"starbase_replacement": "Deathmoon"},
+    "vp_bonuses": {},
+    "cannot_build": ["starbase"],
+    "notes": [
+      "Starbases are replaced by Deathmoons with Transmatter drives."
+    ]
+  },
+  "octantis_autonomy": {
+    "name": "Octantis Autonomy",
+    "expansion": "sotr",
+    "starting_sector": 403,
+    "trade_rate": {"goods": 3, "resources": 1},
+    "starting_storage": {"money": 3, "science": 3, "materials": 3},
+    "starting_resources": {"money": 1, "science": 2, "materials": 1},
+    "starting_colonies": {"home": {"science": 1, "materials": 1}},
+    "starting_ships": {"home": {"interceptor": 1, "cruiser": 0, "dreadnought": 0, "starbase": 0}},
+    "starting_structures": {"home": {"orbital": 0, "monolith": 0}},
+    "starting_techs": ["Evolution Protocol"],
+    "starting_discs_delta": 0,
+    "colony_ships": 3,
+    "action_overrides": {},
+    "build_limits": {},
+    "vp_bonuses": {},
+    "cannot_build": [],
+    "notes": [
+      "Evolution: maintain an Evolution tile pool. During your turn you may flip Colony Ships to discard and redraw that many Evolution tiles.",
+      "Uses shared Evolution tiles with Hydran Progress when both factions are present."
+    ]
+  },
+  "octantis_vanguard": {
+    "name": "Octantis Vanguard",
+    "expansion": "sotr",
+    "starting_sector": 404,
+    "trade_rate": {"goods": 3, "resources": 1},
+    "starting_storage": {"money": 3, "science": 3, "materials": 3},
+    "starting_resources": {"money": 1, "science": 1, "materials": 2},
+    "starting_colonies": {"home": {"science": 1, "materials": 1}},
+    "starting_ships": {"home": {"interceptor": 1, "cruiser": 0, "dreadnought": 0, "starbase": 0}},
+    "starting_structures": {"home": {"orbital": 0, "monolith": 0}},
+    "starting_techs": ["Evolution Protocol"],
+    "starting_discs_delta": 0,
+    "colony_ships": 3,
+    "action_overrides": {},
+    "build_limits": {},
+    "vp_bonuses": {},
+    "cannot_build": [],
+    "notes": [
+      "Evolution: maintain an Evolution tile pool. During your turn you may flip Colony Ships to discard and redraw that many Evolution tiles.",
+      "Vanguard side emphasises military upgrades combined with Evolution bonuses."
+    ]
+  }
+}

--- a/eclipse_ai/species_data.py
+++ b/eclipse_ai/species_data.py
@@ -1,0 +1,86 @@
+"""Utilities for loading faction/species configuration data."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from typing import Dict, Any, Optional
+
+
+@dataclass(frozen=True)
+class SpeciesConfig:
+    """Immutable wrapper around a species configuration block."""
+
+    species_id: str
+    raw: Dict[str, Any]
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.raw.get(key, default)
+
+    @property
+    def name(self) -> str:
+        return self.raw.get("name", self.species_id)
+
+    @property
+    def expansion(self) -> str:
+        return self.raw.get("expansion", "base")
+
+    @property
+    def trade_rate(self) -> Any:
+        return self.raw.get("trade_rate")
+
+
+class SpeciesRegistry:
+    """Singleton-style registry that loads JSON data on demand."""
+
+    def __init__(self, path: Optional[str] = None) -> None:
+        self._path = path or os.path.join(os.path.dirname(__file__), "data", "species.json")
+        self._data: Dict[str, SpeciesConfig] = {}
+        self._meta: Dict[str, Any] = {}
+        self._loaded = False
+
+    def load(self) -> None:
+        if self._loaded:
+            return
+        with open(self._path, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        self._meta = payload.get("_meta", {})
+        species_entries = {k: v for k, v in payload.items() if not k.startswith("_")}
+        for species_id, block in species_entries.items():
+            self._data[species_id] = SpeciesConfig(species_id=species_id, raw=block)
+        self._loaded = True
+
+    @property
+    def meta(self) -> Dict[str, Any]:
+        self.load()
+        return self._meta
+
+    def get(self, species_id: str) -> SpeciesConfig:
+        self.load()
+        try:
+            return self._data[species_id]
+        except KeyError as exc:
+            available = ", ".join(sorted(self._data))
+            raise KeyError(f"Unknown species '{species_id}'. Available: {available}") from exc
+
+    def all_species(self) -> Dict[str, SpeciesConfig]:
+        self.load()
+        return dict(self._data)
+
+
+_registry: Optional[SpeciesRegistry] = None
+
+
+def get_registry(path: Optional[str] = None) -> SpeciesRegistry:
+    global _registry
+    if _registry is None or path is not None:
+        _registry = SpeciesRegistry(path=path)
+    return _registry
+
+
+def get_species(species_id: str) -> SpeciesConfig:
+    return get_registry().get(species_id)
+
+
+def all_species() -> Dict[str, SpeciesConfig]:
+    return get_registry().all_species()

--- a/tests/test_species_data.py
+++ b/tests/test_species_data.py
@@ -1,0 +1,28 @@
+from eclipse_ai import all_species, get_species, SpeciesConfig
+
+
+def test_loads_species_registry() -> None:
+    registry = all_species()
+    assert "terrans" in registry
+    assert "octantis_autonomy" in registry
+    assert isinstance(registry["terrans"], SpeciesConfig)
+
+
+def test_octantis_evolution_note_present() -> None:
+    octantis = get_species("octantis_autonomy")
+    notes = " ".join(octantis.get("notes", []))
+    assert "Evolution" in notes
+    assert "Colony Ships" in notes
+
+
+def test_rho_indi_trade_rate_override() -> None:
+    rho = get_species("rho_indi")
+    trade_rate = rho.trade_rate
+    assert trade_rate == {"goods": 3, "resources": 2}
+
+
+def test_two_player_balance_note() -> None:
+    planta_notes = " ".join(get_species("planta").get("notes", []))
+    draco_notes = " ".join(get_species("draco").get("notes", []))
+    assert "two-player" in planta_notes.lower()
+    assert "two-player" in draco_notes.lower()


### PR DESCRIPTION
## Summary
- add a structured `species.json` that captures trade rates, starting data, and Octantis Evolution notes for base, Rise of the Ancients, and Shadows of the Rift factions
- expose a reusable species registry loader so other modules can query faction metadata
- cover the new data with tests that validate key overrides like Octantis Evolution and Rho Indi trade rates

## Testing
- pytest tests/test_species_data.py


------
https://chatgpt.com/codex/tasks/task_e_68d609fba370832d8493a066c2571323