### PR TITLE
Add endgame VP scoring with module gates

### DIFF
--- a/eclipse_ai/data/constants.py
+++ b/eclipse_ai/data/constants.py
@@ -1,0 +1,10 @@
+"""Victory point constants for Eclipse endgame scoring."""
+from __future__ import annotations
+
+TECH_TRACK_VP = {4: 1, 5: 2, 6: 3, 7: 5}
+DISCOVERY_TILE_VP = 2
+MONOLITH_VP = 3
+TRAITOR_PENALTY = -2
+ALLIANCE_TILE_FACEUP_VP = 2
+ALLIANCE_TILE_BETRAYER_VP = -3
+ANCIENT_KILL_VP = 1

--- a/eclipse_ai/models/player_state.py
+++ b/eclipse_ai/models/player_state.py
@@ -1,0 +1,45 @@
+"""Lightweight player state models used by the scoring helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Literal, Optional
+
+
+@dataclass(slots=True)
+class ReputationTile:
+    """Representation of a kept reputation tile with its printed value."""
+
+    value: int
+    is_special: bool = False
+
+
+@dataclass(slots=True)
+class EvolutionTile:
+    """Subset of Evolution tile data required for endgame scoring."""
+
+    endgame_key: Optional[str] = None
+    value: int = 0
+
+
+AllianceSide = Literal["faceup", "+2", "betrayer", "-3", None]
+
+
+@dataclass(slots=True)
+class PlayerState:
+    """Player view consumed by :mod:`eclipse_ai.scoring` utilities."""
+
+    player_id: str
+    reputation_kept: List[ReputationTile] = field(default_factory=list)
+    ambassadors: int = 0
+    controlled_hex_ids: List[str] = field(default_factory=list)
+    discoveries_kept: int = 0
+    monolith_count: int = 0
+    tech_track_counts: Dict[str, int] = field(default_factory=dict)
+    has_traitor: bool = False
+    alliance_tile: AllianceSide = None
+    ancient_kill_tokens: Dict[str, int] = field(
+        default_factory=lambda: {"cruiser": 0, "dreadnought": 0}
+    )
+    evolution_tiles: List[EvolutionTile] = field(default_factory=list)
+    artifacts_controlled: int = 0
+    controls_galactic_center: bool = False

--- a/eclipse_ai/scoring/__init__.py
+++ b/eclipse_ai/scoring/__init__.py
@@ -1,0 +1,12 @@
+"""Scoring utilities for Eclipse endgame evaluation."""
+from __future__ import annotations
+
+from .endgame import compute_endgame_vp, score_game
+from .species import deathmoon_reputation_draws, unity_deathmoon_bonus
+
+__all__ = [
+    "compute_endgame_vp",
+    "score_game",
+    "unity_deathmoon_bonus",
+    "deathmoon_reputation_draws",
+]

--- a/eclipse_ai/scoring/endgame.py
+++ b/eclipse_ai/scoring/endgame.py
@@ -1,0 +1,305 @@
+"""Endgame victory point breakdowns."""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Mapping, Optional
+
+from ..data.constants import (
+    ALLIANCE_TILE_BETRAYER_VP,
+    ALLIANCE_TILE_FACEUP_VP,
+    ANCIENT_KILL_VP,
+    DISCOVERY_TILE_VP,
+    MONOLITH_VP,
+    TECH_TRACK_VP,
+    TRAITOR_PENALTY,
+)
+from ..models.player_state import EvolutionTile, ReputationTile
+
+
+def compute_endgame_vp(state: Any, player_id: str, modules: Optional[Mapping[str, Any]] = None) -> Dict[str, int]:
+    """Compute the endgame VP breakdown for ``player_id``."""
+
+    modules = modules or {}
+    player = _get_player(state, player_id)
+    if player is None:
+        raise KeyError(f"Unknown player '{player_id}' in state")
+
+    alliances_enabled = _module_enabled(modules, "alliances", "rotA_alliances")
+    new_ancients_enabled = _module_enabled(modules, "new_ancients", "rotA_new_ancients")
+    sor_enabled = _module_enabled(modules, "sor", "shadows_of_the_rift")
+
+    vp_reputation = _reputation_vp(player)
+    vp_ambassadors = int(getattr(player, "ambassadors", 0) or 0)
+    vp_hexes = _hex_vp(state, player)
+    vp_discoveries = int(getattr(player, "discoveries_kept", 0) or 0) * DISCOVERY_TILE_VP
+    vp_monoliths = int(getattr(player, "monolith_count", 0) or 0) * MONOLITH_VP
+    vp_tech_tracks = _tech_track_vp(player)
+    vp_traitor = TRAITOR_PENALTY if bool(getattr(player, "has_traitor", False)) else 0
+    vp_alliance = _alliance_tile_vp(player) if alliances_enabled else 0
+    vp_ancients = _ancient_kill_vp(player) if new_ancients_enabled else 0
+    vp_evolution = _evolution_vp(state, player) if sor_enabled else 0
+
+    total = (
+        vp_reputation
+        + vp_ambassadors
+        + vp_hexes
+        + vp_discoveries
+        + vp_monoliths
+        + vp_tech_tracks
+        + vp_traitor
+        + vp_alliance
+        + vp_ancients
+        + vp_evolution
+    )
+
+    return {
+        "vp_reputation": vp_reputation,
+        "vp_ambassadors": vp_ambassadors,
+        "vp_hexes": vp_hexes,
+        "vp_discoveries": vp_discoveries,
+        "vp_monoliths": vp_monoliths,
+        "vp_tech_tracks": vp_tech_tracks,
+        "vp_traitor": vp_traitor,
+        "vp_rise_alliance_tile": vp_alliance,
+        "vp_rise_ancient_kills": vp_ancients,
+        "vp_sor_evolution": vp_evolution,
+        "total": total,
+    }
+
+
+def score_game(state: Any, modules: Optional[Mapping[str, Any]] = None) -> Dict[str, Any]:
+    """Return per-player endgame VP breakdowns and alliance summaries."""
+
+    modules = modules or {}
+    players: Mapping[str, Any] = getattr(state, "players", {})
+    if not isinstance(players, Mapping):
+        raise TypeError("state.players must be a mapping of player_id -> PlayerState")
+
+    player_breakdowns: Dict[str, Dict[str, int]] = {}
+    for player_id in players:
+        player_breakdowns[player_id] = compute_endgame_vp(state, player_id, modules)
+
+    result: Dict[str, Any] = {"players": player_breakdowns}
+
+    if _module_enabled(modules, "alliances", "rotA_alliances"):
+        teams = _extract_alliance_teams(state, players)
+        if teams:
+            totals = {pid: data["total"] for pid, data in player_breakdowns.items()}
+            team_totals: Dict[str, int] = {}
+            team_average: Dict[str, int] = {}
+            for team_id, members in teams.items():
+                team_total = sum(totals.get(pid, 0) for pid in members)
+                if not members:
+                    continue
+                team_totals[team_id] = team_total
+                team_average[team_id] = team_total // len(members)
+            result["alliances"] = {"team_totals": team_totals, "team_average": team_average}
+
+    return result
+
+
+def _module_enabled(modules: Mapping[str, Any], *keys: str) -> bool:
+    return any(bool(modules.get(key)) for key in keys)
+
+
+def _get_player(state: Any, player_id: str) -> Optional[Any]:
+    players = getattr(state, "players", None)
+    if isinstance(players, Mapping):
+        return players.get(player_id)
+    return None
+
+
+def _reputation_vp(player: Any) -> int:
+    tiles: Iterable[Any] = getattr(player, "reputation_kept", []) or []
+    total = 0
+    for tile in tiles:
+        if tile is None:
+            continue
+        if isinstance(tile, ReputationTile):
+            if tile.is_special:
+                continue
+            total += int(tile.value)
+            continue
+        if isinstance(tile, Mapping):
+            if tile.get("is_special"):
+                continue
+            value = tile.get("value", 0)
+            total += int(value)
+            continue
+        value = getattr(tile, "value", tile)
+        flag = getattr(tile, "is_special", False)
+        if flag:
+            continue
+        total += int(value)
+    return total
+
+
+def _hex_vp(state: Any, player: Any) -> int:
+    hexes = _get_hex_collection(state)
+    if not hexes:
+        return 0
+
+    player_id = getattr(player, "player_id", None)
+    total = 0
+    for hex_id in getattr(player, "controlled_hex_ids", []) or []:
+        hex_obj = hexes.get(hex_id)
+        if hex_obj is None:
+            continue
+        controller = getattr(hex_obj, "controller", getattr(hex_obj, "controlled_by", None))
+        if controller is not None and player_id is not None and controller != player_id:
+            continue
+        total += int(getattr(hex_obj, "vp_value", 0) or 0)
+    return total
+
+
+def _get_hex_collection(state: Any) -> Mapping[str, Any]:
+    map_state = getattr(state, "map", None)
+    if map_state is not None:
+        hexes = getattr(map_state, "hexes", None)
+        if isinstance(hexes, Mapping):
+            return hexes
+    hexes = getattr(state, "hexes", None)
+    if isinstance(hexes, Mapping):
+        return hexes
+    return {}
+
+
+def _tech_track_vp(player: Any) -> int:
+    counts: Mapping[str, Any] = getattr(player, "tech_track_counts", {}) or {}
+
+    def _vp_from_track(count: Any) -> int:
+        try:
+            value = int(count)
+        except (TypeError, ValueError):
+            return 0
+        value = min(value, 7)
+        return int(TECH_TRACK_VP.get(value, 0))
+
+    return sum(_vp_from_track(count) for count in counts.values())
+
+
+def _alliance_tile_vp(player: Any) -> int:
+    tile = getattr(player, "alliance_tile", None)
+    if tile is None:
+        return 0
+    normalized = str(tile).lower()
+    if normalized in {"faceup", "face-up", "face_up", "+2"}:
+        return ALLIANCE_TILE_FACEUP_VP
+    if normalized in {"betrayer", "-3"}:
+        return ALLIANCE_TILE_BETRAYER_VP
+    return 0
+
+
+def _ancient_kill_vp(player: Any) -> int:
+    tokens: Mapping[str, Any] = getattr(player, "ancient_kill_tokens", {}) or {}
+    total = 0
+    for key in ("cruiser", "dreadnought"):
+        try:
+            total += int(tokens.get(key, 0))
+        except (TypeError, ValueError):
+            continue
+    return total * ANCIENT_KILL_VP
+
+
+def _evolution_vp(state: Any, player: Any) -> int:
+    tiles: Iterable[Any] = getattr(player, "evolution_tiles", []) or []
+    if not tiles:
+        return 0
+
+    total = 0
+    for tile in tiles:
+        key, value = _evolution_tile_fields(tile)
+        handler = _EVOLUTION_HANDLERS.get(key)
+        if handler is None:
+            total += int(value)
+        else:
+            total += handler(state, player, int(value))
+    return total
+
+
+def _evolution_tile_fields(tile: Any) -> tuple[Optional[str], int]:
+    if isinstance(tile, EvolutionTile):
+        return tile.endgame_key, int(tile.value)
+    if isinstance(tile, Mapping):
+        key = tile.get("endgame_key") or tile.get("key")
+        value = tile.get("value", tile.get("endgame_value", 0))
+        return key, int(value)
+    key = getattr(tile, "endgame_key", None)
+    value = getattr(tile, "value", 0)
+    try:
+        value = int(value)
+    except (TypeError, ValueError):
+        value = 0
+    return key, value
+
+
+def _controlled_hex_count(player: Any) -> int:
+    return len(getattr(player, "controlled_hex_ids", []) or [])
+
+
+def _artifact_count(player: Any) -> int:
+    try:
+        return int(getattr(player, "artifacts_controlled", 0) or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _has_galactic_center(state: Any, player: Any) -> bool:
+    flag = getattr(player, "controls_galactic_center", None)
+    if flag is not None:
+        return bool(flag)
+    # Fall back to checking whether a tracked hex is explicitly named.
+    for hex_id in getattr(player, "controlled_hex_ids", []) or []:
+        if str(hex_id).lower() in {"galactic_center", "galactic-centre", "gc"}:
+            return True
+    return False
+
+
+def _per_monolith(_: Any, player: Any, value: int) -> int:
+    try:
+        return value * int(getattr(player, "monolith_count", 0) or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _per_two_hex(_: Any, player: Any, value: int) -> int:
+    return value * (_controlled_hex_count(player) // 2)
+
+
+def _per_artifact(_: Any, player: Any, value: int) -> int:
+    return value * _artifact_count(player)
+
+
+def _galactic_center(state: Any, player: Any, value: int) -> int:
+    return value if _has_galactic_center(state, player) else 0
+
+
+_EVOLUTION_HANDLERS: Dict[Optional[str], Any] = {
+    "per_monolith": _per_monolith,
+    "per_two_hex": _per_two_hex,
+    "per_artifact": _per_artifact,
+    "galactic_center": _galactic_center,
+}
+
+
+def _extract_alliance_teams(state: Any, players: Mapping[str, Any]) -> Dict[str, list[str]]:
+    candidate_attrs = ("alliance_teams", "alliances", "teams")
+    for attr in candidate_attrs:
+        data = getattr(state, attr, None)
+        if isinstance(data, Mapping):
+            teams: Dict[str, list[str]] = {}
+            for team_id, members in data.items():
+                if isinstance(members, Iterable) and not isinstance(members, (str, bytes)):
+                    teams[str(team_id)] = [str(pid) for pid in members]
+            if teams:
+                return teams
+    teams: Dict[str, list[str]] = {}
+    for pid, player in players.items():
+        team_id = (
+            getattr(player, "alliance_team", None)
+            or getattr(player, "team", None)
+            or getattr(player, "team_id", None)
+        )
+        if team_id is None:
+            continue
+        teams.setdefault(str(team_id), []).append(str(pid))
+    return teams

--- a/eclipse_ai/scoring/species.py
+++ b/eclipse_ai/scoring/species.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from .game_models import GameState, PlayerState
+from ..game_models import GameState, PlayerState
 
 
 def unity_deathmoon_bonus(state: GameState, player: PlayerState) -> int:

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from eclipse_ai.models.player_state import EvolutionTile, PlayerState, ReputationTile
+from eclipse_ai.scoring import compute_endgame_vp, score_game
+
+
+@dataclass
+class Hex:
+    id: str
+    vp_value: int = 0
+    controller: Optional[str] = None
+
+
+@dataclass
+class MapState:
+    hexes: Dict[str, Hex] = field(default_factory=dict)
+
+
+@dataclass
+class StubState:
+    players: Dict[str, PlayerState]
+    map: MapState = field(default_factory=MapState)
+    alliance_teams: Optional[Dict[str, List[str]]] = None
+
+
+def test_base_example() -> None:
+    hexes = {
+        "A": Hex(id="A", vp_value=2, controller="p1"),
+        "B": Hex(id="B", vp_value=3, controller="p1"),
+    }
+    player = PlayerState(
+        player_id="p1",
+        reputation_kept=[
+            ReputationTile(value=3),
+            ReputationTile(value=2),
+            ReputationTile(value=5, is_special=True),
+        ],
+        ambassadors=2,
+        controlled_hex_ids=["A", "B"],
+        discoveries_kept=1,
+        monolith_count=2,
+        tech_track_counts={"military": 4, "grid": 5, "nano": 6},
+    )
+    state = StubState(players={"p1": player}, map=MapState(hexes=hexes))
+
+    result = compute_endgame_vp(state, "p1", modules={})
+
+    assert result["vp_reputation"] == 5
+    assert result["vp_ambassadors"] == 2
+    assert result["vp_hexes"] == 5
+    assert result["vp_discoveries"] == 2
+    assert result["vp_monoliths"] == 6
+    assert result["vp_tech_tracks"] == 6
+    assert result["vp_traitor"] == 0
+    assert result["total"] == 26
+
+
+def test_tech_track_piecewise() -> None:
+    player = PlayerState(
+        player_id="p2",
+        tech_track_counts={
+            "military": 3,
+            "grid": 4,
+            "nano": 5,
+            "quantum": 6,
+            "biotech": 7,
+            "economy": 8,
+        },
+    )
+    state = StubState(players={"p2": player})
+
+    result = compute_endgame_vp(state, "p2", modules={})
+
+    assert result["vp_tech_tracks"] == 16
+    assert result["total"] == 16
+
+
+def test_traitor_penalty() -> None:
+    state = StubState(
+        players={
+            "p1": PlayerState(player_id="p1", has_traitor=True),
+            "p2": PlayerState(player_id="p2", has_traitor=False),
+        }
+    )
+
+    result_with_traitor = compute_endgame_vp(state, "p1", modules={})
+    result_without_traitor = compute_endgame_vp(state, "p2", modules={})
+
+    assert result_with_traitor["vp_traitor"] == -2
+    assert result_with_traitor["total"] == -2
+    assert result_without_traitor["vp_traitor"] == 0
+    assert result_without_traitor["total"] == 0
+
+
+def test_discoveries_vp_kept_only() -> None:
+    player = PlayerState(player_id="p3", discoveries_kept=3)
+    state = StubState(players={"p3": player})
+
+    result = compute_endgame_vp(state, "p3", modules={})
+
+    assert result["vp_discoveries"] == 6
+    assert result["total"] == 6
+
+
+def test_alliance_tile_values_and_team_average() -> None:
+    players = {
+        "p1": PlayerState(player_id="p1", alliance_tile="faceup"),
+        "p2": PlayerState(player_id="p2", alliance_tile="betrayer"),
+    }
+    state = StubState(players=players, alliance_teams={"team-alpha": ["p1", "p2"]})
+
+    result = score_game(state, modules={"alliances": True})
+
+    assert result["players"]["p1"]["vp_rise_alliance_tile"] == 2
+    assert result["players"]["p2"]["vp_rise_alliance_tile"] == -3
+    alliance_summary = result["alliances"]
+    assert alliance_summary["team_totals"]["team-alpha"] == -1
+    assert alliance_summary["team_average"]["team-alpha"] == -1
+
+
+def test_ancient_kill_tokens_vp() -> None:
+    tokens = {"cruiser": 2, "dreadnought": 1}
+    player = PlayerState(player_id="p4", ancient_kill_tokens=tokens)
+    state = StubState(players={"p4": player})
+
+    result = compute_endgame_vp(state, "p4", modules={"new_ancients": True})
+
+    assert result["vp_rise_ancient_kills"] == 3
+    assert result["total"] == 3
+
+
+def test_sor_evolution_examples() -> None:
+    player = PlayerState(
+        player_id="p5",
+        monolith_count=2,
+        controlled_hex_ids=["A", "B", "C", "D"],
+        artifacts_controlled=3,
+        controls_galactic_center=True,
+        evolution_tiles=[
+            EvolutionTile(endgame_key="per_monolith", value=1),
+            EvolutionTile(endgame_key="per_two_hex", value=1),
+            EvolutionTile(endgame_key="per_artifact", value=1),
+            EvolutionTile(endgame_key="galactic_center", value=3),
+            EvolutionTile(endgame_key=None, value=4),
+        ],
+    )
+    state = StubState(players={"p5": player})
+
+    modules_on = {"sor": True}
+    modules_off = {}
+
+    result_on = compute_endgame_vp(state, "p5", modules=modules_on)
+    result_off = compute_endgame_vp(state, "p5", modules=modules_off)
+
+    assert result_on["vp_sor_evolution"] == 14
+    assert result_off["vp_sor_evolution"] == 0
+    assert result_on["total"] - result_off["total"] == 14


### PR DESCRIPTION
## Summary
- add dedicated scoring constants and lightweight player state models
- implement endgame VP breakdown helpers with alliance, ancient, and evolution hooks
- add unit tests covering base scoring, traitor penalties, alliances, ancients, and SoR tiles

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d610a72fe0832d89ea233b696335bf