### PR TITLE
Implement explore action placement and discovery systems

### DIFF
--- a/eclipse_ai/explore.py
+++ b/eclipse_ai/explore.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+from .map.hex import Hex, MapGraph, rotated_wormholes
+from .map.decks import ExplorationDecks, HexTile, DiscoveryTile, ResourcePool
+
+
+@dataclass
+class PlayerExploreState:
+    player_id: str
+    resources: ResourcePool = field(default_factory=ResourcePool)
+    has_wormhole_generator: bool = False
+    influence_discs: int = 0
+    discovery_vp: int = 0
+    kept_discoveries: list[str] = field(default_factory=list)
+    ancient_tech: int = 0
+    ancient_cruisers: int = 0
+    ancient_parts: int = 0
+    turn_ended: bool = False
+    colony_ships: Dict[str, int] = field(default_factory=lambda: {"yellow": 0, "blue": 0, "brown": 0, "wild": 0})
+
+
+@dataclass
+class ExploreState:
+    map: MapGraph
+    decks: ExplorationDecks
+    players: Dict[str, PlayerExploreState]
+    feature_flags: Dict[str, bool] = field(default_factory=dict)
+
+    def end_turn(self, player_id: str) -> None:
+        self.players[player_id].turn_ended = True
+
+
+def choose_explore_target(state: ExploreState, player_id: str, target: str) -> None:
+    """Choose an unexplored space adjacent to a controlled hex or unpinned ship."""
+
+    edges = state.map.connection_edges(target)
+    if not edges:
+        raise ValueError(f"No unexplored space recorded at {target}")
+    player = state.players[player_id]
+    ok = False
+    for _, (neighbor_id, _) in edges.items():
+        if neighbor_id not in state.map.hexes:
+            continue
+        neighbor = state.map.hexes[neighbor_id]
+        if neighbor.owner == player_id or neighbor.ships.get(player_id, 0) > 0:
+            ok = True
+            break
+    if not ok:
+        raise ValueError("Explore target must touch a hex with your disc or unpinned ship")
+    state.map.set_choice(player_id, target)
+
+
+def draw_sector_tile(state: ExploreState, player_id: str, ring: int) -> HexTile:
+    pos = state.map.explored_choice.get(player_id)
+    if pos is None:
+        raise ValueError("Player has not chosen an exploration target")
+    deck = state.decks.get_sector(ring)
+    return deck.draw()
+
+
+def discard_sector_tile(state: ExploreState, player_id: str, tile: HexTile) -> None:
+    deck = state.decks.get_sector(tile.ring)
+    deck.discard(tile)
+    state.map.clear_choice(player_id)
+    state.end_turn(player_id)
+
+
+def can_place(tile: HexTile, pos: str, orient: int, state: ExploreState, player_id: str) -> bool:
+    assert pos == state.map.explored_choice[player_id]
+    ok = has_full_connection_to_player(tile, orient, player_id, state)
+    if not ok and state.players[player_id].has_wormhole_generator:
+        ok = has_half_connection_to_player(tile, orient, player_id, state)
+    return ok
+
+
+def place_tile(state: ExploreState, player_id: str, tile: HexTile, orient: int) -> Hex:
+    if not 0 <= orient < 6:
+        raise ValueError("Orientation must be between 0 and 5")
+    pos = state.map.explored_choice.get(player_id)
+    if pos is None:
+        raise ValueError("No exploration target recorded for player")
+    if not can_place(tile, pos, orient, state, player_id):
+        raise ValueError("Tile does not connect to a hex with your disc or ship")
+
+    wormholes = rotated_wormholes(tile, orient)
+    placed = Hex(
+        id=pos,
+        ring=tile.ring,
+        wormholes=wormholes,
+        symbols=tuple(tile.symbols),
+        warp_portal=tile.warp_portal,
+        gcds=tile.gcds,
+    )
+    pending = state.map.take_pending_edges(pos)
+    for edge, (neighbor_id, neighbor_edge) in pending.items():
+        placed.neighbors[edge] = neighbor_id
+        if neighbor_id in state.map.hexes:
+            neighbor = state.map.hexes[neighbor_id]
+            neighbor.neighbors[neighbor_edge] = pos
+    state.map.add_hex(placed)
+    _spawn_discovery_and_ancients(state, placed)
+    state.map.clear_choice(player_id)
+    return placed
+
+
+def _spawn_discovery_and_ancients(state: ExploreState, hex_obj: Hex) -> None:
+    if "discovery" in hex_obj.symbols:
+        tile = state.decks.discovery.draw()
+        hex_obj.discovery_tile = tile
+    ancients = sum(1 for symbol in hex_obj.symbols if symbol == "ancient")
+    if ancients:
+        hex_obj.ancients += ancients
+
+
+def has_full_connection_to_player(tile: HexTile, orient: int, player_id: str, state: ExploreState) -> bool:
+    pos = state.map.explored_choice[player_id]
+    wormholes = set(tile.wormholes)
+    edges = state.map.connection_edges(pos)
+    for map_edge, (neighbor_id, neighbor_edge) in edges.items():
+        tile_edge = (map_edge - orient) % 6
+        if tile_edge not in wormholes:
+            continue
+        neighbor = state.map.hexes.get(neighbor_id)
+        if not neighbor:
+            continue
+        if not neighbor.has_wormhole(neighbor_edge):
+            continue
+        if neighbor.has_presence(player_id):
+            return True
+    return False
+
+
+def has_half_connection_to_player(tile: HexTile, orient: int, player_id: str, state: ExploreState) -> bool:
+    pos = state.map.explored_choice[player_id]
+    wormholes = set(tile.wormholes)
+    edges = state.map.connection_edges(pos)
+    for map_edge, (neighbor_id, _) in edges.items():
+        tile_edge = (map_edge - orient) % 6
+        if tile_edge not in wormholes:
+            continue
+        neighbor = state.map.hexes.get(neighbor_id)
+        if not neighbor:
+            continue
+        if neighbor.has_presence(player_id):
+            return True
+    return False
+
+
+def claim_discovery(state: ExploreState, player_id: str, hex_id: str, keep_vp: bool) -> Optional[DiscoveryTile]:
+    hex_obj = state.map.hexes[hex_id]
+    if hex_obj.owner != player_id:
+        raise ValueError("You must control the hex to claim the discovery")
+    if hex_obj.ancients > 0:
+        raise ValueError("Ancients must be cleared before claiming the discovery")
+    tile = hex_obj.discovery_tile
+    if tile is None:
+        raise ValueError("No discovery tile present")
+    player = state.players[player_id]
+    if keep_vp:
+        player.discovery_vp += 2
+        player.kept_discoveries.append(tile.id)
+    else:
+        tile.apply(player)
+        state.decks.discovery.discard(tile)
+    hex_obj.discovery_tile = None
+    return tile

--- a/eclipse_ai/influence.py
+++ b/eclipse_ai/influence.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from .explore import ExploreState
+from .map.hex import MapGraph
+
+
+def place_influence_disc(state: ExploreState, player_id: str, hex_id: str) -> None:
+    hex_obj = state.map.hexes[hex_id]
+    if hex_obj.ancients > 0:
+        raise ValueError("Cannot take control while Ancients remain on the hex")
+    if hex_obj.gcds:
+        raise ValueError("Galactic Center Defense System must be destroyed before control")
+    hex_obj.owner = player_id
+
+
+def _flags(state_or_flags) -> Dict[str, bool]:
+    if isinstance(state_or_flags, ExploreState):
+        return state_or_flags.feature_flags
+    return dict(state_or_flags or {})
+
+
+def connection_allows_influence(map_state: MapGraph, a: str, b: str, *, feature_flags=None, player_has_wg: bool = False) -> bool:
+    flags = _flags(feature_flags)
+    if flags.get("warp_portals") and _both_have_portals(map_state, a, b):
+        return True
+    link = map_state.connection_type(a, b)
+    if link == "full":
+        return True
+    if link == "half" and player_has_wg:
+        return True
+    return False
+
+
+def connection_allows_diplomacy(map_state: MapGraph, a: str, b: str, *, feature_flags=None) -> bool:
+    flags = _flags(feature_flags)
+    if flags.get("warp_portals") and _both_have_portals(map_state, a, b):
+        return True
+    return map_state.connection_type(a, b) == "full"
+
+
+def _both_have_portals(map_state: MapGraph, a: str, b: str) -> bool:
+    hex_a = map_state.hexes.get(a)
+    hex_b = map_state.hexes.get(b)
+    if not hex_a or not hex_b:
+        return False
+    return bool(hex_a.warp_portal and hex_b.warp_portal)

--- a/eclipse_ai/map/__init__.py
+++ b/eclipse_ai/map/__init__.py
@@ -1,0 +1,14 @@
+"""Map data structures for Eclipse hex tiles and adjacency logic."""
+
+from .hex import Hex, MapGraph
+from .decks import HexTile, SectorDeck, DiscoveryDeck, ExplorationDecks, DiscoveryTile
+
+__all__ = [
+    "Hex",
+    "MapGraph",
+    "HexTile",
+    "SectorDeck",
+    "DiscoveryDeck",
+    "ExplorationDecks",
+    "DiscoveryTile",
+]

--- a/eclipse_ai/map/decks.py
+++ b/eclipse_ai/map/decks.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence
+
+
+@dataclass
+class HexTile:
+    """Prototype for an unexplored hex tile."""
+
+    id: str
+    ring: int
+    wormholes: Sequence[int]
+    symbols: Sequence[str] = field(default_factory=tuple)
+    warp_portal: bool = False
+    gcds: bool = False
+
+
+@dataclass
+class DiscoveryTile:
+    """Representation of a discovery tile."""
+
+    id: str
+    effect: str
+    amount: int = 0
+
+    def apply(self, player: "PlayerProtocol") -> None:
+        """Execute the immediate effect of the tile on ``player``."""
+
+        if self.effect == "money":
+            player.resources.money += self.amount
+        elif self.effect == "science":
+            player.resources.science += self.amount
+        elif self.effect == "materials":
+            player.resources.materials += self.amount
+        elif self.effect == "ancient_tech":
+            player.ancient_tech += 1
+        elif self.effect == "ancient_cruiser":
+            player.ancient_cruisers += 1
+        elif self.effect == "ancient_part":
+            player.ancient_parts += 1
+        else:
+            raise ValueError(f"Unknown discovery effect: {self.effect}")
+
+
+class PlayerProtocol:
+    resources: "ResourcePool"
+    ancient_tech: int
+    ancient_cruisers: int
+    ancient_parts: int
+
+
+@dataclass
+class ResourcePool:
+    money: int = 0
+    science: int = 0
+    materials: int = 0
+
+
+@dataclass
+class _DeckBase:
+    draw_pile: List
+    discard_pile: List = field(default_factory=list)
+    rng: random.Random = field(default_factory=random.Random)
+
+    def draw(self):
+        if not self.draw_pile:
+            self._reshuffle_from_discards()
+        if not self.draw_pile:
+            raise RuntimeError("Deck is empty and no discards are available")
+        return self.draw_pile.pop()
+
+    def discard(self, item) -> None:
+        self.discard_pile.append(item)
+
+    def _reshuffle_from_discards(self) -> None:
+        if not self.discard_pile:
+            return
+        self.draw_pile = list(self.discard_pile)
+        self.discard_pile.clear()
+        self.rng.shuffle(self.draw_pile)
+
+
+@dataclass
+class SectorDeck(_DeckBase):
+    """Sector stack for a given ring."""
+
+    ring: int = 1
+
+    def __init__(self, *, ring: int, tiles: Optional[Sequence[HexTile]] = None, rng: Optional[random.Random] = None):
+        tiles = list(tiles or [])
+        rng = rng or random.Random()
+        super().__init__(draw_pile=list(tiles), discard_pile=[], rng=rng)
+        self.ring = ring
+
+
+@dataclass
+class DiscoveryDeck(_DeckBase):
+    """Stack for discovery tiles."""
+
+    def __init__(self, *, tiles: Optional[Sequence[DiscoveryTile]] = None, rng: Optional[random.Random] = None):
+        tiles = list(tiles or [])
+        rng = rng or random.Random()
+        super().__init__(draw_pile=list(tiles), discard_pile=[], rng=rng)
+
+
+@dataclass
+class ExplorationDecks:
+    sectors: Dict[int, SectorDeck]
+    discovery: DiscoveryDeck
+
+    def get_sector(self, ring: int) -> SectorDeck:
+        try:
+            return self.sectors[ring]
+        except KeyError as exc:
+            raise KeyError(f"No sector deck for ring {ring}") from exc

--- a/eclipse_ai/map/hex.py
+++ b/eclipse_ai/map/hex.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+from .decks import HexTile, DiscoveryTile
+
+
+def rotate_edge(edge: int, orient: int) -> int:
+    return (edge + orient) % 6
+
+
+def opposite_edge(edge: int) -> int:
+    return (edge + 3) % 6
+
+
+def rotated_wormholes(tile: HexTile, orient: int) -> Tuple[int, ...]:
+    return tuple(sorted(rotate_edge(edge, orient) for edge in tile.wormholes))
+
+
+@dataclass
+class Hex:
+    id: str
+    ring: int
+    wormholes: Tuple[int, ...]
+    symbols: Tuple[str, ...] = tuple()
+    warp_portal: bool = False
+    gcds: bool = False
+    neighbors: Dict[int, str] = field(default_factory=dict)
+    owner: Optional[str] = None
+    ships: Dict[str, int] = field(default_factory=dict)
+    ancients: int = 0
+    discovery_tile: Optional[DiscoveryTile] = None
+
+    def has_wormhole(self, edge: int) -> bool:
+        return edge in self.wormholes
+
+    def has_presence(self, player_id: str) -> bool:
+        return self.owner == player_id or self.ships.get(player_id, 0) > 0
+
+
+@dataclass
+class MapGraph:
+    hexes: Dict[str, Hex] = field(default_factory=dict)
+    explored_choice: Dict[str, str] = field(default_factory=dict)
+    pending_edges: Dict[str, Dict[int, Tuple[str, int]]] = field(default_factory=dict)
+
+    def add_hex(self, hex_obj: Hex) -> None:
+        self.hexes[hex_obj.id] = hex_obj
+
+    def register_exploration_target(self, *, origin: str, edge: int, target: str) -> None:
+        origin_hex = self.hexes[origin]
+        origin_hex.neighbors[edge] = target
+        new_edge = opposite_edge(edge)
+        self.pending_edges.setdefault(target, {})[new_edge] = (origin, edge)
+
+    def set_choice(self, player_id: str, target: str) -> None:
+        if target not in self.pending_edges:
+            raise ValueError(f"No unexplored space recorded at {target}")
+        self.explored_choice[player_id] = target
+
+    def clear_choice(self, player_id: str) -> None:
+        self.explored_choice.pop(player_id, None)
+
+    def take_pending_edges(self, pos: str) -> Dict[int, Tuple[str, int]]:
+        return self.pending_edges.pop(pos, {})
+
+    def connection_edges(self, pos: str) -> Dict[int, Tuple[str, int]]:
+        return dict(self.pending_edges.get(pos, {}))
+
+    def neighbors(self, hex_id: str) -> Iterable[str]:
+        hx = self.hexes[hex_id]
+        for nb in hx.neighbors.values():
+            if nb is None:
+                continue
+            if nb in self.hexes:
+                yield nb
+
+    def connection_type(self, a: str, b: str) -> str:
+        if a == b:
+            return "full"
+        hex_a = self.hexes[a]
+        hex_b = self.hexes[b]
+        for edge, nb in hex_a.neighbors.items():
+            if nb != b:
+                continue
+            opp = opposite_edge(edge)
+            a_has = hex_a.has_wormhole(edge)
+            b_has = hex_b.has_wormhole(opp)
+            if a_has and b_has:
+                return "full"
+            if a_has or b_has:
+                return "half"
+        return "none"
+
+    def ensure_neighbor_link(self, a: str, edge: int, b: str) -> None:
+        self.hexes[a].neighbors[edge] = b
+        self.hexes[b].neighbors[opposite_edge(edge)] = a
+
+
+__all__ = [
+    "Hex",
+    "MapGraph",
+    "rotate_edge",
+    "opposite_edge",
+    "rotated_wormholes",
+]

--- a/tests/test_explore.py
+++ b/tests/test_explore.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from eclipse_ai.explore import (
+    ExploreState,
+    PlayerExploreState,
+    choose_explore_target,
+    claim_discovery,
+    draw_sector_tile,
+    discard_sector_tile,
+    place_tile,
+)
+from eclipse_ai.influence import (
+    connection_allows_diplomacy,
+    connection_allows_influence,
+    place_influence_disc,
+)
+from eclipse_ai.map.decks import (
+    DiscoveryDeck,
+    DiscoveryTile,
+    ExplorationDecks,
+    HexTile,
+    SectorDeck,
+)
+from eclipse_ai.map.hex import Hex, MapGraph
+
+
+PLAYER_ID = "P1"
+
+
+def _make_state(
+    *,
+    sector_tiles: list[HexTile] | None = None,
+    discovery_tiles: list[DiscoveryTile] | None = None,
+    home_wormholes: tuple[int, ...] = (0,),
+    has_wormhole_generator: bool = False,
+) -> ExploreState:
+    map_state = MapGraph()
+    home = Hex(id="Home", ring=1, wormholes=home_wormholes)
+    home.owner = PLAYER_ID
+    map_state.add_hex(home)
+    map_state.register_exploration_target(origin="Home", edge=0, target="T1")
+    sectors = {
+        1: SectorDeck(ring=1, tiles=sector_tiles or [], rng=random.Random(0)),
+    }
+    discovery = DiscoveryDeck(tiles=discovery_tiles or [], rng=random.Random(0))
+    decks = ExplorationDecks(sectors=sectors, discovery=discovery)
+    players = {
+        PLAYER_ID: PlayerExploreState(
+            player_id=PLAYER_ID,
+            has_wormhole_generator=has_wormhole_generator,
+        )
+    }
+    return ExploreState(map=map_state, decks=decks, players=players, feature_flags={"warp_portals": True})
+
+
+def test_explore_discard_ends_turn() -> None:
+    tile = HexTile(id="New", ring=1, wormholes=(3,))
+    state = _make_state(sector_tiles=[tile])
+    choose_explore_target(state, PLAYER_ID, "T1")
+    drawn = draw_sector_tile(state, PLAYER_ID, 1)
+    discard_sector_tile(state, PLAYER_ID, drawn)
+    assert state.players[PLAYER_ID].turn_ended is True
+
+
+def test_place_requires_connection() -> None:
+    tile = HexTile(id="New", ring=1, wormholes=(3,))
+    state = _make_state(sector_tiles=[tile], home_wormholes=())
+    choose_explore_target(state, PLAYER_ID, "T1")
+    draw_sector_tile(state, PLAYER_ID, 1)
+    with pytest.raises(ValueError):
+        place_tile(state, PLAYER_ID, tile, orient=0)
+    state.players[PLAYER_ID].has_wormhole_generator = True
+    placed = place_tile(state, PLAYER_ID, tile, orient=0)
+    assert placed.id == "T1"
+
+
+def test_spawn_discovery_and_ancients() -> None:
+    tile = HexTile(
+        id="AncientDiscovery",
+        ring=1,
+        wormholes=(3,),
+        symbols=("discovery", "ancient", "ancient"),
+    )
+    discovery_tile = DiscoveryTile(id="D1", effect="money", amount=5)
+    state = _make_state(sector_tiles=[tile], discovery_tiles=[discovery_tile])
+    choose_explore_target(state, PLAYER_ID, "T1")
+    draw_sector_tile(state, PLAYER_ID, 1)
+    placed = place_tile(state, PLAYER_ID, tile, orient=0)
+    assert placed.discovery_tile == discovery_tile
+    assert placed.ancients == 2
+
+
+def test_control_requires_clearing_ancients_and_gcds() -> None:
+    map_state = MapGraph()
+    target = Hex(id="Target", ring=1, wormholes=())
+    target.ancients = 1
+    map_state.add_hex(target)
+    decks = ExplorationDecks(
+        sectors={1: SectorDeck(ring=1, tiles=[], rng=random.Random(0))},
+        discovery=DiscoveryDeck(tiles=[], rng=random.Random(0)),
+    )
+    players = {PLAYER_ID: PlayerExploreState(player_id=PLAYER_ID)}
+    state = ExploreState(map=map_state, decks=decks, players=players, feature_flags={})
+    with pytest.raises(ValueError):
+        place_influence_disc(state, PLAYER_ID, "Target")
+    target.ancients = 0
+    target.gcds = True
+    with pytest.raises(ValueError):
+        place_influence_disc(state, PLAYER_ID, "Target")
+    target.gcds = False
+    place_influence_disc(state, PLAYER_ID, "Target")
+    assert map_state.hexes["Target"].owner == PLAYER_ID
+
+
+def test_discovery_vp_or_benefit_choice() -> None:
+    discovery_tile = DiscoveryTile(id="D-money", effect="money", amount=5)
+    map_state = MapGraph()
+    hex_obj = Hex(id="DiscoveryHex", ring=1, wormholes=())
+    hex_obj.owner = PLAYER_ID
+    hex_obj.discovery_tile = discovery_tile
+    map_state.add_hex(hex_obj)
+    decks = ExplorationDecks(
+        sectors={1: SectorDeck(ring=1, tiles=[], rng=random.Random(0))},
+        discovery=DiscoveryDeck(tiles=[], rng=random.Random(0)),
+    )
+    players = {PLAYER_ID: PlayerExploreState(player_id=PLAYER_ID)}
+    state = ExploreState(map=map_state, decks=decks, players=players, feature_flags={})
+    claim_discovery(state, PLAYER_ID, "DiscoveryHex", keep_vp=False)
+    assert players[PLAYER_ID].resources.money == 5
+    assert state.decks.discovery.discard_pile  # spent tile is discarded
+    hex_obj.discovery_tile = DiscoveryTile(id="D-vp", effect="materials", amount=3)
+    claim_discovery(state, PLAYER_ID, "DiscoveryHex", keep_vp=True)
+    assert players[PLAYER_ID].discovery_vp == 2
+    assert hex_obj.discovery_tile is None
+
+
+def test_sector_stack_reshuffle_on_empty() -> None:
+    tile = HexTile(id="Sector", ring=1, wormholes=(3,))
+    state = _make_state(sector_tiles=[tile])
+    choose_explore_target(state, PLAYER_ID, "T1")
+    first = draw_sector_tile(state, PLAYER_ID, 1)
+    discard_sector_tile(state, PLAYER_ID, first)
+    state.players[PLAYER_ID].turn_ended = False
+    choose_explore_target(state, PLAYER_ID, "T1")
+    second = draw_sector_tile(state, PLAYER_ID, 1)
+    assert second == first
+
+
+def test_discovery_reshuffle() -> None:
+    deck = DiscoveryDeck(tiles=[DiscoveryTile(id="D1", effect="science", amount=3)], rng=random.Random(0))
+    first = deck.draw()
+    deck.discard(first)
+    second = deck.draw()
+    assert second == first
+
+
+def test_warp_portal_adjacency_for_influence_and_diplomacy() -> None:
+    map_state = MapGraph()
+    a = Hex(id="A", ring=1, wormholes=())
+    b = Hex(id="B", ring=1, wormholes=())
+    a.warp_portal = True
+    b.warp_portal = True
+    map_state.add_hex(a)
+    map_state.add_hex(b)
+    flags = {"warp_portals": True}
+    assert connection_allows_influence(map_state, "A", "B", feature_flags=flags)
+    assert connection_allows_diplomacy(map_state, "A", "B", feature_flags=flags)
+    flags["warp_portals"] = False
+    assert not connection_allows_influence(map_state, "A", "B", feature_flags=flags)
+    assert not connection_allows_diplomacy(map_state, "A", "B", feature_flags=flags)
+
+
+def test_diplomacy_requires_full_link_not_wg() -> None:
+    map_state = MapGraph()
+    a = Hex(id="A", ring=1, wormholes=(0,))
+    b = Hex(id="B", ring=1, wormholes=())
+    map_state.add_hex(a)
+    map_state.add_hex(b)
+    map_state.ensure_neighbor_link("A", 0, "B")
+    flags = {"warp_portals": False}
+    assert not connection_allows_influence(map_state, "A", "B", feature_flags=flags)
+    assert connection_allows_influence(map_state, "A", "B", feature_flags=flags, player_has_wg=True)
+    assert not connection_allows_diplomacy(map_state, "A", "B", feature_flags=flags)


### PR DESCRIPTION
## Summary
- add exploration state helpers to handle tile draws, placements, discovery resolution, and wormhole validation
- implement map utilities and deck management for sector and discovery stacks, including reshuffle handling and warp portal adjacency helpers
- gate influence by ancients/GCDS and add comprehensive exploration tests covering placement, discoveries, portals, and diplomacy edge cases

## Testing
- `pytest tests/test_explore.py`


------
https://chatgpt.com/codex/tasks/task_e_68d611374ebc832dbf6146030930b703