### PR TITLE
Fix wormhole generator exploration connectivity

### DIFF
--- a/eclipse_ai/explore.py
+++ b/eclipse_ai/explore.py
@@ -137,12 +137,14 @@ def has_half_connection_to_player(tile: HexTile, orient: int, player_id: str, st
     pos = state.map.explored_choice[player_id]
     wormholes = set(tile.wormholes)
     edges = state.map.connection_edges(pos)
-    for map_edge, (neighbor_id, _) in edges.items():
-        tile_edge = (map_edge - orient) % 6
-        if tile_edge not in wormholes:
-            continue
+    for map_edge, (neighbor_id, neighbor_edge) in edges.items():
         neighbor = state.map.hexes.get(neighbor_id)
         if not neighbor:
+            continue
+        tile_edge = (map_edge - orient) % 6
+        tile_has_wormhole = tile_edge in wormholes
+        neighbor_has_wormhole = neighbor.has_wormhole(neighbor_edge)
+        if not (tile_has_wormhole or neighbor_has_wormhole):
             continue
         if neighbor.has_presence(player_id):
             return True

--- a/tests/test_explore.py
+++ b/tests/test_explore.py
@@ -78,6 +78,18 @@ def test_place_requires_connection() -> None:
     assert placed.id == "T1"
 
 
+def test_wormhole_generator_allows_neighbor_wormhole_only() -> None:
+    tile = HexTile(id="Half", ring=1, wormholes=())
+    state = _make_state(sector_tiles=[tile], home_wormholes=(0,))
+    choose_explore_target(state, PLAYER_ID, "T1")
+    draw_sector_tile(state, PLAYER_ID, 1)
+    with pytest.raises(ValueError):
+        place_tile(state, PLAYER_ID, tile, orient=0)
+    state.players[PLAYER_ID].has_wormhole_generator = True
+    placed = place_tile(state, PLAYER_ID, tile, orient=0)
+    assert placed.id == "T1"
+
+
 def test_spawn_discovery_and_ancients() -> None:
     tile = HexTile(
         id="AncientDiscovery",


### PR DESCRIPTION
## Summary
- treat adjacent hexes with a wormhole as valid exploration targets for players with a wormhole generator
- add a regression test ensuring exploration works when only the neighbor has a wormhole

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d61538067c832da608eacf89d86966