### PR TITLE
Refresh README for current Eclipse AI layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
-# Quick start
+# Eclipse AI Toolkit
 
-1. **Run the Orion smoke test from the CLI.** Sample Orion round-one images and annotations live in `eclipse_ai/eclipse_test/`. Execute the bundled harness to parse those assets, run Monte Carlo planning, and persist a JSON summary.【F:eclipse_ai/eclipse_test/run_test.py†L12-L270】
+Tools for reconstructing *Eclipse: New Dawn for the Galaxy* game states from table snapshots,
+simulating outcomes, and recommending plans. The code is packaged as `eclipse_ai`, which can be
+imported or driven from notebooks and CLI harnesses.
+
+## Quick start
+
+1. **Run the bundled Orion smoke test.** Parse the demo board/tech photos, assemble a game state,
+   and execute the Monte Carlo planner. 【F:eclipse_ai/eclipse_test/run_test.py†L1-L12】【F:eclipse_ai/main.py†L35-L74】
 
    ```bash
    python -m eclipse_ai.eclipse_test.run_test \
@@ -10,7 +17,8 @@
        --output orion_round1.json
    ```
 
-2. **Render a shareable report.** Convert the saved JSON into an SVG card that summarizes the recommended plans and their risk profile.【F:eclipse_ai/eclipse_test/render_report.py†L1-L162】
+2. **Render a shareable report.** Convert a saved JSON run into an SVG summary card for
+   presentation or archival. 【F:eclipse_ai/eclipse_test/render_report.py†L1-L94】
 
    ```bash
    python -m eclipse_ai.eclipse_test.render_report orion_round1.json \
@@ -18,93 +26,71 @@
        --title "Orion Opening"
    ```
 
-   The SVG embeds the EV/risk details for the top plans and can be opened directly in a browser or vector editor. Re-run the CLI with different planner settings or manual overrides to generate alternative scenarios.
-
-# Eclipse AI Toolkit
-
-This repository contains an experimental toolkit for parsing snapshots of an *Eclipse: New Dawn for the Galaxy* board, reconstructing a game state, simulating likely outcomes, and producing turn recommendations. The code is structured as a lightweight Python package (`eclipse_ai`) that can be imported into downstream projects or used from notebooks that orchestrate camera input, state overrides, and plan visualizations.
-
-## High-level workflow
-
-1. **Image ingestion** – Raw board or tech display photos are rectified, white-balanced, and annotated with metadata (e.g., a projected hex grid) to make downstream parsing easier. Optional dependencies such as OpenCV, Pillow, and ArUco marker detection power these corrections, with graceful degradation when they are unavailable.【F:eclipse_ai/image_ingestion.py†L1-L218】【F:eclipse_ai/image_ingestion.py†L219-L301】
-2. **Board & tech parsing** – Calibrated images are converted into structured data:
-   * `board_parser.parse_board` prefers JSON sidecars but can fall back to HSV-based token detection or a demo map if computer vision fails.【F:eclipse_ai/board_parser.py†L1-L176】【F:eclipse_ai/board_parser.py†L177-L278】
-   * `tech_parser.parse_tech` reads available technologies from sidecar files or OCR, normalizing noisy text into canonical names.【F:eclipse_ai/tech_parser.py†L1-L121】【F:eclipse_ai/tech_parser.py†L122-L229】
-3. **State assembly & overrides** – Parsed fragments are merged into a canonical `GameState` dataclass. Helpers ensure discovered players exist, tile bags are instantiated, and manual overrides (nested dicts or dotted paths) can patch any portion of the state.【F:eclipse_ai/state_assembler.py†L1-L118】【F:eclipse_ai/game_models.py†L1-L168】
-4. **Belief tracking** – `uncertainty.BeliefState` maintains opponent tech archetype posteriors via discrete HMMs and tracks exploration bag uncertainty with a particle filter. Observations from parsed tech automatically update these models before planning.【F:eclipse_ai/uncertainty.py†L1-L232】【F:eclipse_ai/main.py†L32-L83】
-5. **Action generation & evaluation** – `rules_engine.legal_actions` enumerates plausible moves for the active player, covering explore, research, build, move, upgrade, influence, diplomacy, and pass actions.【F:eclipse_ai/rules_engine.py†L1-L206】 Each candidate is scored by `evaluator.evaluate_action`, which fuses heuristics with Monte Carlo exploration and combat simulators to estimate VP delta and risk.【F:eclipse_ai/evaluator.py†L1-L241】【F:eclipse_ai/simulators/exploration.py†L1-L224】【F:eclipse_ai/simulators/combat.py†L1-L210】
-6. **Search & planning** – `search_policy.MCTSPlanner` runs a single-player Monte Carlo Tree Search (P-UCT) over the enumerated actions, assembling top-ranked plans with risk-adjusted values and optional rollouts for deeper horizons.【F:eclipse_ai/search_policy.py†L1-L217】
-7. **Visualization & packaging** – Results include serialized plan steps, belief summaries, expected bag compositions, and optional vector overlays for front-end rendering or augmented reality prototypes.【F:eclipse_ai/main.py†L92-L114】【F:eclipse_ai/overlay.py†L1-L185】
-
-The notebooks and PDFs in the repository capture prototype experiments for exploration heuristics, combat simulations, and state tree visualizations; they illustrate how to orchestrate the Python package in interactive settings.
-
 ## Repository layout
 
-```
-Eclipse Exploration Simulation.ipynb   ← notebook exploring the end-to-end pipeline
-Eclpise Combat Simulator.ipynb         ← combat tuning & validation notebook
-state_tree_sim.ipynb                   ← experiments with plan trees / uncertainty
-Eclipse Exploration Simulation.pdf     ← exported reference for the exploration notebook
-Eclpise Combat Simulator.pdf           ← exported combat notebook reference
-eclipse_tiles.csv                      ← sample tile bag data for exploration sims
-eclipse_tiles.pdf                      ← annotated tile reference sheet
-
-eclipse_ai/                            ← importable package
-  ├── main.py                          ← `recommend` orchestration entry point
-  ├── image_ingestion.py               ← photo calibration & metadata extraction
-  ├── board_parser.py                  ← board token detection & sidecar loading
-  ├── tech_parser.py                   ← tech display parsing via OCR/sidecars
-  ├── state_assembler.py               ← merge map & tech into a `GameState`
-  ├── game_models.py                   ← dataclasses and helpers for canonical state
-  ├── rules_engine.py                  ← pragmatic action enumerators
-  ├── evaluator.py                     ← action scoring (exploration/combat EV)
-  ├── search_policy.py                 ← MCTS planner & plan data structures
-  ├── overlay.py                       ← plan overlay generation helpers
-  ├── uncertainty.py                   ← belief state & particle filters
-  ├── validators.py                    ← rule conformance and state validation checks
-  ├── simulators/                      ← Monte Carlo combat & exploration engines
-  └── eclipse_test/                    ← CLI harnesses, fixtures, and report renderer
+```text
+eclipse_ai/                      ← importable Python package
+  board_parser.py                ← translate calibrated board images into map data
+  tech_parser.py                 ← extract technology market state from the tech display
+  state_assembler.py             ← merge parsed fragments and manual overrides into GameState
+  game_models.py                 ← dataclasses for players, hexes, bags, and action payloads
+  movement.py                    ← helpers for faction-specific activation limits
+  research.py                    ← shared logic for tech availability and cost adjustments
+  influence.py                   ← influence disc accounting, diplomacy hooks, upkeep helpers
+  map/                           ← sector deck metadata and canonical hex definitions
+  simulators/                    ← combat and exploration Monte Carlo kernels
+  scoring/                       ← endgame VP calculators and species valuation helpers
+  search_policy.py               ← Monte Carlo tree search over enumerated action sequences
+  round_flow.py                  ← action/phase management and upkeep resolution
+  overlay.py                     ← vector overlay builders for UI/AR consumers
+  eclipse_test/                  ← CLI smoke tests, fixtures, and SVG renderer
+notebooks & PDFs                 ← exploratory analyses of exploration, combat, and plan trees
+scripts/                         ← utilities for development and data wrangling
+tests/                           ← pytest suite covering rules, combat, economy, and parsing
 ```
 
-## Using the planner
+## Core workflow
 
-```python
-from eclipse_ai import recommend
+1. **Image ingestion.** `load_and_calibrate` rectifies and annotates raw photos (EXIF-aware when
+   Pillow/OpenCV are installed) before parsing. 【F:eclipse_ai/image_ingestion.py†L1-L138】
+2. **Parsing.** `parse_board` and `parse_tech` translate calibrated images or JSON sidecars into
+   structured map and tech display objects. 【F:eclipse_ai/board_parser.py†L1-L146】【F:eclipse_ai/tech_parser.py†L1-L145】
+3. **State assembly.** `assemble_state` combines parsed fragments with tech definitions, ensures
+   bags/players exist, and applies manual overrides for simulations. 【F:eclipse_ai/state_assembler.py†L38-L114】
+4. **Action enumeration.** `rules_engine.legal_actions` produces pragmatic explore/research/build
+   move/upgrade/influence/diplomacy options, delegating to helper modules for research pricing and
+   other rule nuances. 【F:eclipse_ai/rules_engine.py†L28-L86】【F:eclipse_ai/research.py†L1-L112】
+5. **Simulation & scoring.** Exploration and combat Monte Carlo kernels feed
+   `evaluator.evaluate_action`, which aggregates risk-aware VP estimates for each candidate action.
+   【F:eclipse_ai/simulators/exploration.py†L1-L118】【F:eclipse_ai/simulators/combat.py†L1-L132】【F:eclipse_ai/evaluator.py†L10-L49】
+6. **Planning.** `MCTSPlanner.plan` rolls out multi-step action sequences, applying configurable
+   simulation counts, depth, and risk aversion to produce ranked plans and overlays. 【F:eclipse_ai/search_policy.py†L1-L112】【F:eclipse_ai/main.py†L75-L115】
+7. **Round flow helpers.** `round_flow.begin_round`, `take_action`, `take_reaction`, and upkeep
+   utilities maintain action discs, turn order, and economic collapse rules for downstream
+   integrations. 【F:eclipse_ai/round_flow.py†L19-L118】【F:eclipse_ai/round_flow.py†L120-L196】
 
-result = recommend(
-    board_image_path="board.jpg",      # or None if providing prior state
-    tech_image_path="tech.jpg",
-    prior_state=None,                   # optional cached GameState
-    manual_inputs={                     # optional overrides (state + planner knobs)
-        "players.you.resources.money": 12,
-        "_planner": {"simulations": 800, "depth": 3, "risk_aversion": 0.3},
-    },
-    top_k=3,
-)
+## Running tests
 
-for plan in result["plans"]:
-    print(plan["score"], plan["risk"], plan["steps"])
+Install dependencies (see `requirements.txt` if present in your environment) and execute the
+pytest suite from the repository root:
+
+```bash
+pytest
 ```
 
-`recommend` automatically calibrates photos, parses board/tech state, applies manual overrides, updates opponent beliefs, runs MCTS, and returns JSON-serializable structures ready for UIs or reporting.【F:eclipse_ai/main.py†L32-L114】 The helper functions in `overlay.py` can turn each plan into vector annotations for an AR overlay or web front-end.【F:eclipse_ai/overlay.py†L1-L185】
-
-## Optional dependencies
-
-The package is designed to degrade gracefully when computer-vision libraries are absent. If you install the following extras, more automation becomes available:
-
-* **OpenCV + NumPy** – Required for token detection, image rectification, and computer vision-assisted tech parsing.【F:eclipse_ai/board_parser.py†L1-L176】【F:eclipse_ai/image_ingestion.py†L1-L218】
-* **Pillow** – Used for EXIF-aware image loading when OpenCV is available.【F:eclipse_ai/image_ingestion.py†L1-L218】
-* **pytesseract** – Enables OCR of the tech display when sidecar data is missing.【F:eclipse_ai/tech_parser.py†L1-L121】
-
-Without these packages the system falls back to sidecar JSON or demo data, ensuring the rest of the pipeline (state assembly, action generation, planning, and visualization) remains testable.
+The suite covers legality gates, combat solvers, research costs, scoring heuristics, and state
+assembly invariants. 【F:tests/test_rules_engine.py†L1-L33】【F:tests/test_scoring.py†L1-L33】【F:tests/test_state_assembler.py†L1-L52】
 
 ## Extending the toolkit
 
-* Add richer rule handling or faction-specific logic by extending `rules_engine` and the dataclasses in `game_models`.【F:eclipse_ai/rules_engine.py†L1-L206】【F:eclipse_ai/game_models.py†L1-L168】
-* Plug in alternative evaluation heuristics by modifying or augmenting `evaluator`—for example, add economic simulators or alliance modeling.【F:eclipse_ai/evaluator.py†L1-L236】
-* Persist and hydrate belief state particles via `BeliefState.to_dict()` / `from_dict()` to maintain continuity across turns.【F:eclipse_ai/uncertainty.py†L151-L232】
-* The MCTS planner accepts configuration overrides (simulation count, depth, risk aversion) through the `_planner` manual input to experiment with different planning tempos.【F:eclipse_ai/main.py†L83-L103】【F:eclipse_ai/search_policy.py†L1-L217】
+* Add new faction perks or movement tweaks via `PlayerState` flags and the helpers in
+  `movement.py` / `influence.py`. 【F:eclipse_ai/game_models.py†L90-L200】【F:eclipse_ai/movement.py†L1-L32】【F:eclipse_ai/influence.py†L1-L48】
+* Expand research catalogs or alternate scoring heuristics by editing the data files under
+  `eclipse_ai/data/` and the modules in `research.py` / `scoring/`. 【F:eclipse_ai/data/tech.json†L1-L40】【F:eclipse_ai/research.py†L1-L112】【F:eclipse_ai/scoring/endgame.py†L1-L76】
+* Build richer UIs by consuming the JSON payload from `recommend` and the vector overlays returned
+  by `plan_overlays`. 【F:eclipse_ai/main.py†L75-L115】【F:eclipse_ai/overlay.py†L1-L152】
 
 ## License
 
-This repository is provided for experimentation with Eclipse strategy aids. No explicit license has been declared; treat the contents as proprietary unless you have permission from the maintainers.
+No explicit license has been declared. Treat the contents as proprietary unless you have
+permission from the maintainers.


### PR DESCRIPTION
## Summary
- update the README quick start to highlight the current `recommend` pipeline and report renderer
- rewrite the repository overview to match the reorganized package layout and helper modules
- document the core workflow, testing entry point, and extension hooks with up-to-date references

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d6154ddb9c832db1a4c07278ee5e7d