### PR TITLE
Adjust Orion opening fixtures

### DIFF
--- a/tests/legal_cases/orion_turn1.py
+++ b/tests/legal_cases/orion_turn1.py
@@ -100,7 +100,7 @@ _ORION_TURN1_ROUND1_4P: Dict[str, Any] = {
                 ],
                 "pieces": {
                     "P1": {
-                        "ships": {"interceptor": 2, "cruiser": 1},
+                        "ships": {"interceptor": 0, "cruiser": 1},
                         "starbase": 0,
                         "discs": 1,
                         "cubes": {"yellow": 1, "blue": 1, "brown": 1},
@@ -168,7 +168,20 @@ _ORION_TURN1_ROUND1_4P: Dict[str, Any] = {
         }
     },
     "tech_display": {
-        "available": ["Plasma Cannon I", "Fusion Drive I", "Advanced Mining"],
+        "available": [
+            "Plasma Cannon I",
+            "Fusion Drive I",
+            "Advanced Mining",
+            "Positron Computer",
+            "Gauss Shield",
+            "Neutron Absorber",
+            "Advanced Robotics",
+            "Quantum Grid",
+            "Wormhole Generator",
+            "Antimatter Cannon",
+            "Nanorobots",
+            "Improved Hull",
+        ],
         "tier_counts": {"I": 6, "II": 4, "III": 2},
     },
     "bags": {"R1": {"unknown": 4}, "R2": {"unknown": 3}},


### PR DESCRIPTION
## Summary
- remove the Orion interceptors from the round-one legality fixture to match the intended setup
- expand the mocked tech display to show the full set of 12 tiles on the board

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6fafc399c832d8de5e1ef6504dcd2