### PR TITLE
Expose legal action metadata and plan sequencing updates

### DIFF
--- a/eclipse_ai/game_models.py
+++ b/eclipse_ai/game_models.py
@@ -271,6 +271,9 @@ class GameState:
     alliances: Dict[str, Alliance] = field(default_factory=dict)
     reactions_active: Dict[str, bool] = field(default_factory=dict)
     connectivity_metrics: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    possible_actions: Set[ActionType] = field(default_factory=set)
+    can_explore: bool = False
+    can_move_ships: bool = False
 
     def to_json(self) -> str:
         def _normalize(value: Any) -> Any:


### PR DESCRIPTION
## Summary
- add action availability metadata fields to `GameState`
- populate the metadata while enumerating legal actions, including explore/move flags
- build plan suggestions with a rolling theoretical game state so later steps reflect earlier moves

## Testing
- pytest -q tests/test_planner.py *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d70c9604dc832d9519d211c18db182