### PR TITLE
Default GameState can_explore to true

### DIFF
--- a/eclipse_ai/game_models.py
+++ b/eclipse_ai/game_models.py
@@ -271,6 +271,9 @@ class GameState:
     alliances: Dict[str, Alliance] = field(default_factory=dict)
     reactions_active: Dict[str, bool] = field(default_factory=dict)
     connectivity_metrics: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    possible_actions: Set[ActionType] = field(default_factory=set)
+    can_explore: bool = True
+    can_move_ships: bool = False
 
     def to_json(self) -> str:
         def _normalize(value: Any) -> Any:


### PR DESCRIPTION
## Summary
- default the new GameState.can_explore metadata flag to True so callers assume exploration is possible unless ruled out by legal action generation

## Testing
- pytest -q *(fails: indentation error in eclipse_ai/scoring/endgame.py during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_68d70c9604dc832d9519d211c18db182