### PR TITLE
Add plan legality validation and mobility metadata

### DIFF
--- a/eclipse_ai/main.py
+++ b/eclipse_ai/main.py
@@ -97,6 +97,7 @@ def recommend(
             "score": float(p.total_score),
             "risk": float(p.risk),
             "steps": steps,
+            "state_summary": dict(p.state_summary),
             "overlays": plan_overlays(p)
         })
 


### PR DESCRIPTION
## Summary
- use the new game state metadata (possible actions, mobility flags, connectivity) while scoring plans and expose it in the plan output
- validate each candidate plan by replaying it through the legal move generator and refreshing the resulting state so plans stay within the rules

## Testing
- pytest *(fails: existing IndentationError in eclipse_ai/scoring/endgame.py)*

------
https://chatgpt.com/codex/tasks/task_e_68d70f062040832d99d53387aaf0573a