### PR TITLE
Enforce movement capability checks in adjacency classification

### DIFF
--- a/eclipse_ai/search_policy.py
+++ b/eclipse_ai/search_policy.py
@@ -648,7 +648,14 @@ def _activate_single_ship(state: GameState, player: PlayerState, ship_class: str
         if src_hex.has_gcds:
             raise ValueError("GCDS blocks movement through the Galactic Center")
 
-        connection_type = classify_connection(state, player, current_hex_id, next_hex_id)
+        connection_type = classify_connection(
+            state,
+            player,
+            current_hex_id,
+            next_hex_id,
+            ship_design=design,
+            ship_class=ship_class,
+        )
         if connection_type not in LEGAL_CONNECTION_TYPES:
             raise ValueError("No legal connection between hexes")
 


### PR DESCRIPTION
## Summary
- ensure movement connection classification is aware of wormhole generator tech and jump-drive equipped ships
- respect warp-portal feature flags while still allowing default portal networks when expansions are active
- provide ship blueprints to movement validation so illegal jump edges are rejected earlier

## Testing
- pytest tests/test_movement_rules.py
- pytest tests/test_legality_cases_orion.py

------
https://chatgpt.com/codex/tasks/task_e_68d7140d9510832daa1f61e8fc957ca6