### PR TITLE
Enhance test report step summaries

### DIFF
--- a/eclipse_ai/main.py
+++ b/eclipse_ai/main.py
@@ -92,7 +92,16 @@ def recommend(
     # 5) Package results
     out_plans: List[Dict[str, Any]] = []
     for p in plans:
-        steps = [{"action": s.action.type.value, "payload": s.action.payload, "score": float(s.score.expected_vp), "risk": float(s.score.risk)} for s in p.steps]
+        steps = [
+            {
+                "action": s.action.type.value,
+                "payload": s.action.payload,
+                "score": float(s.score.expected_vp),
+                "risk": float(s.score.risk),
+                "details": dict(s.score.details),
+            }
+            for s in p.steps
+        ]
         out_plans.append({
             "score": float(p.total_score),
             "risk": float(p.risk),


### PR DESCRIPTION
## Summary
- include score detail metadata in exported plan steps so test reports can explain decision context
- expand the SVG test report renderer to summarize rationale, resource costs, expected gains, and only show risk for probabilistic steps

## Testing
- python -m compileall eclipse_ai/main.py eclipse_ai/eclipse_test/render_report.py

------
https://chatgpt.com/codex/tasks/task_e_68d716d1048c832da2ced2dadcab9460