### PR TITLE
chore: add dx tooling and ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Lint
+        run: |
+          ruff check .
+          ruff format --check .
+      - name: Run tests
+        run: pytest -q

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.8
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+      - id: ruff-format
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.17.0
+    hooks:
+      - id: pyupgrade
+        args: ["--py310-plus"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Eclipse AI Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing
+
+Thank you for helping improve Eclipse AI! This guide summarizes the workflow we use for
+changes and the checks that keep the project healthy.
+
+## Getting started
+
+1. Create and activate a virtual environment.
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+2. Install dependencies, including development tools.
+   ```bash
+   pip install -e ".[dev]"
+   ```
+3. Install the Git hooks so formatting and linting run automatically.
+   ```bash
+   pre-commit install
+   ```
+
+## Development workflow
+
+* Follow the architecture described in `Agents.md`: models → rules → simulators → planner.
+* Keep notebooks and data paths stable; add new helpers instead of moving existing files.
+* Organize work into focused branches (for example `chore/dx-ci-license`).
+* Write tests alongside changes. Prefer deterministic seeds so results are reproducible.
+
+## Checks before opening a pull request
+
+Run these commands locally and ensure they succeed:
+
+```bash
+ruff check .
+ruff format --check .
+pytest -q
+```
+
+If you add slow-running simulations, mark the tests with `@pytest.mark.slow` so the default
+CI matrix stays fast.
+
+## Pull requests
+
+* Keep diffs narrow and reference the relevant milestone from the roadmap.
+* Include a summary of the change, impacted modules, and how it was validated.
+* Ensure GitHub Actions is green before requesting review.
+* By submitting a contribution you agree that your work is licensed under the project
+  license (MIT).
+
+We appreciate your contributions—thank you for helping us ship a stronger Eclipse AI agent!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,43 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "eclipse-ai"
+version = "0.1.0"
+requires-python = ">=3.10"
+description = "AI planning tools and simulators for Eclipse"
+dynamic = ["dependencies"]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4",
+    "pytest-cov>=4.1",
+    "ruff>=0.5.0",
+    "black>=24.4.0",
+    "mypy>=1.9.0",
+    "pre-commit>=3.7.0",
+]
+
+[tool.setuptools]
+packages = ["eclipse_ai"]
+
+[tool.pytest.ini_options]
+addopts = "-q"
+testpaths = ["tests"]
+
+[tool.black]
+line-length = 100
+target-version = ["py310"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+[tool.ruff.lint]
+select = ["E", "F", "I", "W", "UP", "B"]
+ignore = ["E501"]
+
+[tool.mypy]
+python_version = "3.10"
+disallow_untyped_defs = true
+ignore_missing_imports = true


### PR DESCRIPTION
## Summary
- add a pyproject configuration with formatting, linting, typing, and pytest settings
- configure pre-commit hooks and a GitHub Actions workflow that runs lint and tests on Python 3.10–3.12
- include an MIT license and a contributor quickstart guide

## Testing
- not run (tooling/configuration changes only)

------
https://chatgpt.com/codex/tasks/task_e_68df14e90094832d8ae2b32ff017c450