### PR TITLE
chore: add tooling and CI guardrails

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+
+- Use seeded MCTS with progressive widening; evaluator calls simulators.
+- Tighten legality checks (discs, market, bag, frontier, phase).
+- Add DX/CI; license.
+
+## Validation
+
+- [ ] pytest -q
+- [ ] ruff check .
+- [ ] ruff format --check .
+- [ ] Scenario A/B goldens pass
+- [ ] Planner legality invariant holds

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Ruff lint
+        run: ruff check .
+      - name: Ruff format check
+        run: ruff format --check .
+      - name: Run tests
+        run: pytest -q

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.8
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+      - id: ruff-format
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.17.0
+    hooks:
+      - id: pyupgrade
+        args: ["--py310-plus"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Eclipse AI Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing to Eclipse AI
+
+Thanks for helping improve the Eclipse AI planner! This guide summarizes the recommended
+workflow so that every pull request stays consistent and easy to review.
+
+## Quickstart
+
+1. Create a virtual environment and install dependencies:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -e ".[dev]"
+   ```
+2. Enable the pre-commit hooks to format and lint on save:
+   ```bash
+   pre-commit install
+   ```
+3. Run the checks locally before pushing:
+   ```bash
+   ruff check .
+   ruff format --check .
+   pytest -q
+   ```
+
+## Development workflow
+
+- Follow the architecture documented in `Agents.md`; update existing modules in place instead of
+  duplicating logic.
+- Keep pull requests focused. The preferred flow is one branch per milestone as outlined in the
+  project plan.
+- Add or update tests whenever you change gameplay logic. Mark expensive simulations with
+  `@pytest.mark.slow` so they can be skipped in the default CI matrix.
+- When in doubt, open a draft PR early to discuss the approach.
+
+## Pull request checklist
+
+Before requesting review:
+
+- [ ] Format and lint cleanly (`ruff format --check .`, `ruff check .`).
+- [ ] All tests pass locally (`pytest -q`).
+- [ ] Update documentation, comments, or changelog entries when behavior changes.
+- [ ] Ensure new files include appropriate licensing headers if required.
+
+CI runs the same commands across Python 3.10–3.12, so a green pipeline locally should map to a
+passing PR.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,43 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "eclipse-ai"
+version = "0.1.0"
+description = "AI planning tools for Eclipse board game simulations"
+readme = "README.md"
+authors = [{ name = "Eclipse AI Contributors" }]
+requires-python = ">=3.10"
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
+    "black>=24.4.0",
+    "mypy>=1.9.0",
+    "pre-commit>=3.7.0",
+    "pytest-cov>=4.1",
+    "pytest>=7.4",
+    "ruff>=0.5.0",
+]
+
+[tool.pytest.ini_options]
+addopts = "-q"
+testpaths = ["tests"]
+
+[tool.black]
+line-length = 100
+target-version = ["py310"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W", "UP", "B"]
+ignore = ["E501"]
+
+[tool.mypy]
+python_version = "3.10"
+disallow_untyped_defs = true
+ignore_missing_imports = true


### PR DESCRIPTION
## Summary
- add a pyproject with formatter, linter, type checker, and test defaults plus a dev extra
- configure pre-commit hooks and a repository PR template to standardize contributions
- set up MIT licensing and a CI workflow covering Python 3.10–3.12

## Testing
- pytest -q *(fails: existing IndentationError in eclipse_ai/scoring/endgame.py)*

------
https://chatgpt.com/codex/tasks/task_e_68df14e90094832d8ae2b32ff017c450